### PR TITLE
chore(raft): expose leader/term from server

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -289,6 +289,13 @@ public interface RaftServer {
   Role getRole();
 
   /**
+   * Returns the server's term.
+   *
+   * @return the server's term
+   */
+  long getTerm();
+
+  /**
    * Returns whether the server is the leader.
    *
    * @return whether the server is the leader

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -72,6 +72,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public long getTerm() {
+    return context.getTerm();
+  }
+
+  @Override
   public void addRoleChangeListener(Consumer<Role> listener) {
     context.addRoleChangeListener(listener);
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -79,12 +79,16 @@ public class RaftPartition implements Partition {
 
   @Override
   public long term() {
-    return client != null ? client.term() : 0;
+    return server != null ? server.getTerm() : 0;
   }
 
   @Override
   public MemberId primary() {
     return client != null ? client.leader() : null;
+  }
+
+  public Role getRole() {
+    return server != null ? server.getRole() : null;
   }
 
   public void addRoleChangeListener(Consumer<Role> listener) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -135,6 +135,14 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return server.compact();
   }
 
+  public Role getRole() {
+    return server.getRole();
+  }
+
+  public long getTerm() {
+    return server.getTerm();
+  }
+
   public void addRoleChangeListener(Consumer<Role> listener) {
     if (server == null) {
       deferredRoleChangeListeners.add(listener);


### PR DESCRIPTION
- exposes leader/term of raft server through the partition
- fixes issue where partition leader is null until client updates itself
- fixes issue where partition term is always 0

closes #9