### PR TITLE
chore(dist): fix docker builds

### DIFF
--- a/dist/Dockerfile
+++ b/dist/Dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile
 
-FROM java:8
+FROM openjdk:8
 
 RUN apt-get update -y && apt-get install -y iptables stress
 


### PR DESCRIPTION
- change base image from java:8 to openjdk:8 to fix broken builds

closes #11 