### PR TITLE
fix(raft): reset snapshot index on failure

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendResponse.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/AppendResponse.java
@@ -39,12 +39,14 @@ public class AppendResponse extends AbstractRaftResponse {
   private final long term;
   private final boolean succeeded;
   private final long lastLogIndex;
+  private final long lastSnapshotIndex;
 
-  public AppendResponse(Status status, RaftError error, long term, boolean succeeded, long lastLogIndex) {
+  public AppendResponse(Status status, RaftError error, long term, boolean succeeded, long lastLogIndex, long lastSnapshotIndex) {
     super(status, error);
     this.term = term;
     this.succeeded = succeeded;
     this.lastLogIndex = lastLogIndex;
+    this.lastSnapshotIndex = lastSnapshotIndex;
   }
 
   /**
@@ -74,9 +76,18 @@ public class AppendResponse extends AbstractRaftResponse {
     return lastLogIndex;
   }
 
+  /**
+   * Returns the index of the replica's last snapshot
+   *
+   * @return The index of the responding replica's last snapshot
+   */
+  public long lastSnapshotIndex() {
+    return lastSnapshotIndex;
+  }
+
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), status, term, succeeded, lastLogIndex);
+    return Objects.hash(getClass(), status, term, succeeded, lastLogIndex, lastSnapshotIndex);
   }
 
   @Override
@@ -86,7 +97,8 @@ public class AppendResponse extends AbstractRaftResponse {
       return response.status == status
           && response.term == term
           && response.succeeded == succeeded
-          && response.lastLogIndex == lastLogIndex;
+          && response.lastLogIndex == lastLogIndex
+          && response.lastSnapshotIndex == lastSnapshotIndex;
     }
     return false;
   }
@@ -99,6 +111,7 @@ public class AppendResponse extends AbstractRaftResponse {
           .add("term", term)
           .add("succeeded", succeeded)
           .add("lastLogIndex", lastLogIndex)
+          .add("lastSnapshotIndex", lastSnapshotIndex)
           .toString();
     } else {
       return toStringHelper(this)
@@ -115,6 +128,7 @@ public class AppendResponse extends AbstractRaftResponse {
     private long term;
     private boolean succeeded;
     private long lastLogIndex;
+    private long lastSnapshotIndex;
 
     /**
      * Sets the response term.
@@ -153,12 +167,19 @@ public class AppendResponse extends AbstractRaftResponse {
       return this;
     }
 
+    public Builder withLastSnapshotIndex(long lastSnapshotIndex) {
+      checkArgument(lastSnapshotIndex >= 0, "lastSnapshotIndex must be positive");
+      this.lastSnapshotIndex = lastSnapshotIndex;
+      return this;
+    }
+
     @Override
     protected void validate() {
       super.validate();
       if (status == Status.OK) {
         checkArgument(term > 0, "term must be positive");
         checkArgument(lastLogIndex >= 0, "lastLogIndex must be positive");
+        checkArgument(lastSnapshotIndex >= 0, "lastSnapshotIndex must be positive");
       }
     }
 
@@ -168,7 +189,7 @@ public class AppendResponse extends AbstractRaftResponse {
     @Override
     public AppendResponse build() {
       validate();
-      return new AppendResponse(status, error, term, succeeded, lastLogIndex);
+      return new AppendResponse(status, error, term, succeeded, lastLogIndex, lastSnapshotIndex);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -238,6 +238,7 @@ abstract class AbstractAppender implements AutoCloseable {
     else {
       resetMatchIndex(member, response);
       resetNextIndex(member, response);
+      resetSnapshotIndex(member, response);
 
       // If there are more entries to send then attempt to send another commit.
       if (response.lastLogIndex() != request.prevLogIndex() && hasMoreEntries(member)) {
@@ -311,6 +312,17 @@ abstract class AbstractAppender implements AutoCloseable {
     if (member.getLogReader().getNextIndex() != nextIndex) {
       member.getLogReader().reset(nextIndex);
       log.trace("Reset next index for {} to {}", member, nextIndex);
+    }
+  }
+
+  /**
+   * Resets the snapshot index of the member when a response fails.
+   */
+  protected void resetSnapshotIndex(RaftMemberContext member, AppendResponse response) {
+    final long snapshotIndex = response.lastSnapshotIndex();
+    if (member.getSnapshotIndex() != snapshotIndex) {
+      member.setSnapshotIndex(snapshotIndex);
+      log.trace("Reset snapshot index for {} to {}", member, snapshotIndex);
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -404,6 +404,7 @@ final class LeaderAppender extends AbstractAppender {
       member.appendFailed();
       resetMatchIndex(member, response);
       resetNextIndex(member, response);
+      resetSnapshotIndex(member, response);
 
       // If there are more entries to send then attempt to send another commit.
       if (hasMoreEntries(member)) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -544,6 +544,7 @@ public final class LeaderRole extends ActiveRole {
           .withTerm(raft.getTerm())
           .withSucceeded(false)
           .withLastLogIndex(raft.getLogWriter().getLastIndex())
+          .withLastSnapshotIndex(raft.getSnapshotStore().getCurrentSnapshotIndex())
           .build()));
     } else {
       raft.setLeader(request.leader());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -365,6 +365,7 @@ public class PassiveRole extends InactiveRole {
         .withTerm(raft.getTerm())
         .withSucceeded(succeeded)
         .withLastLogIndex(lastLogIndex)
+        .withLastSnapshotIndex(raft.getSnapshotStore().getCurrentSnapshotIndex())
         .build()));
     return succeeded;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -99,6 +99,16 @@ public class SnapshotStore implements AutoCloseable {
   }
 
   /**
+   * Returns the index of the current snapshot. Defaults to 0.
+   *
+   * @return the index of the current snapshot
+   */
+  public long getCurrentSnapshotIndex() {
+    final Snapshot snapshot = getCurrentSnapshot();
+    return snapshot != null ? snapshot.index() : 0L;
+  }
+
+  /**
    * Returns the snapshot at the given index.
    *
    * @param index the index for which to lookup the snapshot

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.protocols.raft;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.cluster.MemberId;
@@ -89,6 +90,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -96,7 +98,10 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -1221,6 +1226,79 @@ public class RaftTest extends ConcurrentTestCase {
     await(5000);
   }
 
+  @Test
+  public void testSnapshotSentOnDataLoss() throws Throwable {
+    final List<RaftMember> members =
+        Lists.newArrayList(createMember(), createMember(), createMember());
+    final Map<MemberId, RaftStorage> storages =
+        members.stream()
+            .map(RaftMember::memberId)
+            .collect(Collectors.toMap(Function.identity(), this::createStorage));
+    final Map<MemberId, RaftServer> servers =
+        storages.entrySet().stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, this::createServer));
+
+    // wait for cluster to start
+    startCluster(servers);
+
+    // fill two segments then compact so we have at least one snapshot
+    final RaftClient client = createClient(members);
+    final TestPrimitive primitive = createPrimitive(client);
+    fillSegment(primitive);
+    fillSegment(primitive);
+    reduceFutures(servers.values().stream().map(RaftServer::compact)).thenRun(this::resume);
+    await(30000);
+
+    // partition into leader/followers
+    final Map<Boolean, List<RaftMember>> collect =
+        members.stream()
+            .collect(Collectors.partitioningBy(m -> servers.get(m.memberId()).isLeader()));
+    final RaftMember leader = collect.get(true).get(0);
+    final RaftStorage leaderStorage = storages.get(leader.memberId());
+    final RaftMember slave = collect.get(false).get(0);
+    final RaftStorage slaveStorage = storages.get(slave.memberId());
+
+    // shutdown client + primitive
+    primitive.close().thenCompose(nothing -> client.close()).thenRun(this::resume);
+    await(30000);
+
+    // shutdown other node
+    final RaftMember other = collect.get(false).get(1);
+    servers.get(other.memberId()).shutdown().thenRun(this::resume);
+    await(30000);
+
+    // shutdown slave and recreate from scratch
+    final RaftServer slaveServer = recreateServerWithDataLoss(leader, slave, servers.get(slave.memberId()), slaveStorage);
+    assertEquals(leaderStorage.openSnapshotStore().getCurrentSnapshotIndex(), slaveStorage.openSnapshotStore().getCurrentSnapshotIndex());
+
+    // and again a second time to ensure the snapshot index of the member is reset
+    recreateServerWithDataLoss(leader, slave, slaveServer, slaveStorage);
+    assertEquals(leaderStorage.openSnapshotStore().getCurrentSnapshotIndex(), slaveStorage.openSnapshotStore().getCurrentSnapshotIndex());
+  }
+
+  private RaftServer recreateServerWithDataLoss(RaftMember leader, RaftMember member, RaftServer server, RaftStorage storage) throws TimeoutException {
+    server.shutdown().thenRun(this::resume);
+    await(30000);
+    deleteStorage(storage);
+
+    final RaftServer newServer = createServer(member.memberId(), b -> b.withStorage(storage));
+    newServer.bootstrap(leader.memberId()).thenRun(this::resume);
+    await(30000);
+    return newServer;
+  }
+
+  private void deleteStorage(RaftStorage storage) {
+    storage.deleteSnapshotStore();
+    storage.deleteLog();
+    storage.deleteMetaStore();
+  }
+
+  private void fillSegment(TestPrimitive primitive) throws InterruptedException, ExecutionException, TimeoutException {
+    final String entry = RandomStringUtils.randomAscii(1024);
+    primitive.write(entry).get(5, TimeUnit.SECONDS);
+    IntStream.range(0, 10 - 1).forEach(i -> primitive.write(entry).join());
+  }
+
   /**
    * Returns the next unique member identifier.
    *
@@ -1290,38 +1368,75 @@ public class RaftTest extends ConcurrentTestCase {
     return servers;
   }
 
+  private RaftMember createMember() {
+    final RaftMember member = nextMember(RaftMember.Type.ACTIVE);
+    members.add(member);
+
+    return member;
+  }
+
+  private void startCluster(Map<MemberId, RaftServer> servers) throws TimeoutException {
+    final List<MemberId> members = new ArrayList<>(servers.keySet());
+    final CompletableFuture[] bootstrapped = new CompletableFuture[members.size()];
+    servers.values().stream().map(s -> s.bootstrap(members)).collect(Collectors.toList()).toArray(bootstrapped);
+
+    CompletableFuture.allOf(bootstrapped).thenRun(this::resume);
+    await(30000);
+  }
+
   /**
    * Creates a Raft server.
    */
   private RaftServer createServer(MemberId memberId) {
-    RaftServer.Builder builder = RaftServer.builder(memberId)
-        .withMembershipService(mock(ClusterMembershipService.class))
-        .withProtocol(protocolFactory.newServerProtocol(memberId))
-        .withStorage(RaftStorage.builder()
-            .withStorageLevel(StorageLevel.DISK)
-            .withDirectory(new File(String.format("target/test-logs/%s", memberId)))
-            .withNamespace(NAMESPACE)
-            .withMaxSegmentSize(1024 * 10)
-            .withMaxEntriesPerSegment(10)
-            .build());
+    return createServer(memberId, b -> b.withStorage(createStorage(memberId)));
+  }
 
-    RaftServer server = builder.build();
+  private RaftServer createServer(MemberId memberId, Function<RaftServer.Builder, RaftServer.Builder> configurator) {
+    final RaftServer.Builder defaults =
+        RaftServer.builder(memberId)
+            .withMembershipService(mock(ClusterMembershipService.class))
+            .withProtocol(protocolFactory.newServerProtocol(memberId));
+    final RaftServer server = configurator.apply(defaults).build();
 
     servers.add(server);
     return server;
+  }
+
+  private RaftServer createServer(Map.Entry<MemberId, RaftStorage> entry) {
+    return createServer(entry.getKey(), b -> b.withStorage(entry.getValue()));
+  }
+
+  private RaftStorage createStorage(MemberId memberId) {
+    return createStorage(memberId, Function.identity());
+  }
+
+  private RaftStorage createStorage(MemberId memberId, Function<RaftStorage.Builder, RaftStorage.Builder> configurator) {
+    final RaftStorage.Builder defaults =
+        RaftStorage.builder()
+            .withStorageLevel(StorageLevel.DISK)
+            .withDirectory(new File(String.format("target/test-logs/%s", memberId)))
+            .withMaxEntriesPerSegment(10)
+            .withMaxSegmentSize(1024 * 10)
+            .withNamespace(NAMESPACE);
+    return configurator.apply(defaults).build();
   }
 
   /**
    * Creates a Raft client.
    */
   private RaftClient createClient() throws Throwable {
-    MemberId memberId = nextNodeId();
-    RaftClient client = RaftClient.builder()
-        .withMemberId(memberId)
-        .withPartitionId(PartitionId.from("test", 1))
-        .withProtocol(protocolFactory.newClientProtocol(memberId))
-        .build();
-    client.connect(members.stream().map(RaftMember::memberId).collect(Collectors.toList())).thenRun(this::resume);
+    return createClient(members);
+  }
+
+  private RaftClient createClient(List<RaftMember> members) throws Throwable {
+    final MemberId memberId = nextNodeId();
+    final List<MemberId> memberIds = members.stream().map(RaftMember::memberId).collect(Collectors.toList());
+    final RaftClient client = RaftClient.builder()
+            .withMemberId(memberId)
+            .withPartitionId(PartitionId.from("test", 1))
+            .withProtocol(protocolFactory.newClientProtocol(memberId))
+            .build();
+    client.connect(memberIds).thenRun(this::resume);
     await(30000);
     clients.add(client);
     return client;
@@ -1370,6 +1485,13 @@ public class RaftTest extends ConcurrentTestCase {
     when(registry.createPrimitive(any(String.class), any(PrimitiveType.class))).thenReturn(CompletableFuture.completedFuture(new PrimitiveInfo("raft-test", TestPrimitiveType.INSTANCE)));
     when(registry.deletePrimitive(any(String.class))).thenReturn(CompletableFuture.completedFuture(null));
     return new TestPrimitiveImpl(proxy, registry);
+  }
+
+  private CompletableFuture<Void> reduceFutures(Stream<CompletableFuture> stream) {
+    final List<CompletableFuture> list = stream.collect(Collectors.toList());
+    final CompletableFuture[] array = new CompletableFuture[list.size()];
+
+    return CompletableFuture.allOf(list.toArray(array));
   }
 
   @Before


### PR DESCRIPTION
- resets the snapshotIndex of a member to 0 (initial state) when we reset its index