### PR TITLE
Don't commit non replicated entries upon reconnecting

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -117,6 +117,7 @@ public class RaftContext implements AutoCloseable {
   private long commitIndex;
   private volatile long firstCommitIndex;
   private volatile long lastApplied;
+  private volatile long lastAppliedTerm;
 
   @SuppressWarnings("unchecked")
   public RaftContext(
@@ -526,10 +527,11 @@ public class RaftContext implements AutoCloseable {
   /**
    * Sets the last applied index.
    *
-   * @param lastApplied the last applied index
+   * @param lastApplied the last applied index and the last applied term
    */
-  public void setLastApplied(long lastApplied) {
+  public void setLastApplied(long lastApplied, long lastAppliedTerm) {
     this.lastApplied = Math.max(this.lastApplied, lastApplied);
+    this.lastAppliedTerm = Math.max(this.lastAppliedTerm, lastAppliedTerm);
     if (state == State.ACTIVE) {
       threadContext.execute(() -> {
         if (state == State.ACTIVE && this.lastApplied >= firstCommitIndex) {
@@ -547,6 +549,15 @@ public class RaftContext implements AutoCloseable {
    */
   public long getLastApplied() {
     return lastApplied;
+  }
+
+  /**
+   * Returns the term of the last applied entry.
+   *
+   * @return the last applied index
+   */
+  public long getLastAppliedTerm() {
+    return lastAppliedTerm;
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -364,8 +364,9 @@ public class RaftServiceManager implements AutoCloseable {
           throw new IllegalStateException("inconsistent index applying entry " + index + ": " + entry);
         }
         CompletableFuture future = futures.remove(index);
+        final long term = entry.entry().term();
         apply(entry).whenComplete((r, e) -> {
-          raft.setLastApplied(index);
+          raft.setLastApplied(index, term);
           if (future != null) {
             if (e == null) {
               future.complete(r);
@@ -452,7 +453,7 @@ public class RaftServiceManager implements AutoCloseable {
    * Takes snapshots for the given index.
    */
   Snapshot snapshot() {
-    Snapshot snapshot = raft.getSnapshotStore().newTemporarySnapshot(raft.getLastApplied(), new WallClockTimestamp());
+    Snapshot snapshot = raft.getSnapshotStore().newTemporarySnapshot(raft.getLastApplied(), raft.getLastAppliedTerm(), new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       for (RaftServiceContext service : raft.getServices()) {
         writer.buffer().mark();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
@@ -49,13 +49,14 @@ public class InstallRequest extends AbstractRaftRequest {
   private final long term;
   private final MemberId leader;
   private final long index;
+  private final long snapshotTerm;
   private final long timestamp;
   private final int version;
   private final int offset;
   private final byte[] data;
   private final boolean complete;
 
-  public InstallRequest(long term, MemberId leader, long index, long timestamp, int version, int offset, byte[] data, boolean complete) {
+  public InstallRequest(long term, MemberId leader, long index, long snapshotTerm, long timestamp, int version, int offset, byte[] data, boolean complete) {
     this.term = term;
     this.leader = leader;
     this.index = index;
@@ -64,6 +65,7 @@ public class InstallRequest extends AbstractRaftRequest {
     this.offset = offset;
     this.data = data;
     this.complete = complete;
+    this.snapshotTerm = snapshotTerm;
   }
 
   /**
@@ -73,6 +75,15 @@ public class InstallRequest extends AbstractRaftRequest {
    */
   public long term() {
     return term;
+  }
+
+  /**
+   * Returns the term of the last applied entry in the snapshot.
+   *
+   * @return The snapshot term.
+   */
+  public long snapshotTerm() {
+    return snapshotTerm;
   }
 
   /**
@@ -140,7 +151,7 @@ public class InstallRequest extends AbstractRaftRequest {
 
   @Override
   public int hashCode() {
-    return Objects.hash(getClass(), term, leader, index, offset, complete, data);
+    return Objects.hash(getClass(), term, leader, index, offset, complete, data, snapshotTerm);
   }
 
   @Override
@@ -152,6 +163,7 @@ public class InstallRequest extends AbstractRaftRequest {
           && request.index == index
           && request.offset == offset
           && request.complete == complete
+          && request.snapshotTerm == snapshotTerm
           && Arrays.equals(request.data, data);
     }
     return false;
@@ -163,6 +175,7 @@ public class InstallRequest extends AbstractRaftRequest {
         .add("term", term)
         .add("leader", leader)
         .add("index", index)
+        .add("snapshotTerm", snapshotTerm)
         .add("timestamp", timestamp)
         .add("version", version)
         .add("offset", offset)
@@ -183,6 +196,7 @@ public class InstallRequest extends AbstractRaftRequest {
     private int offset;
     private byte[] data;
     private boolean complete;
+    private long snapshotTerm;
 
     /**
      * Sets the request term.
@@ -206,6 +220,12 @@ public class InstallRequest extends AbstractRaftRequest {
      */
     public Builder withLeader(MemberId leader) {
       this.leader = checkNotNull(leader, "leader cannot be null");
+      return this;
+    }
+
+    public Builder withSnapshotTerm(long term) {
+      checkArgument(term > 0, "snapshotTerm must be positive");
+      this.snapshotTerm = term;
       return this;
     }
 
@@ -286,6 +306,7 @@ public class InstallRequest extends AbstractRaftRequest {
       checkArgument(term > 0, "term must be positive");
       checkNotNull(leader, "leader cannot be null");
       checkArgument(index >= 0, "index must be positive");
+      checkArgument(snapshotTerm > 0, "snapshotTerm must be positive");
       checkArgument(offset >= 0, "offset must be positive");
       checkNotNull(data, "data cannot be null");
     }
@@ -296,7 +317,7 @@ public class InstallRequest extends AbstractRaftRequest {
     @Override
     public InstallRequest build() {
       validate();
-      return new InstallRequest(term, leader, index, timestamp, version, offset, data, complete);
+      return new InstallRequest(term, leader, index,  snapshotTerm, timestamp, version, offset, data, complete);
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -101,11 +101,9 @@ abstract class AbstractAppender implements AutoCloseable {
     Indexed<RaftLogEntry> prevEntry = reader != null ? reader.getCurrentEntry() : null;
 
     DefaultRaftMember leader = raft.getLeader();
-    return AppendRequest.builder()
+    return builderWithPreviousEntry(prevEntry)
         .withTerm(raft.getTerm())
         .withLeader(leader != null ? leader.memberId() : null)
-        .withPrevLogIndex(prevEntry != null ? prevEntry.index() : reader != null ? reader.getFirstIndex() - 1 : 0)
-        .withPrevLogTerm(prevEntry != null ? prevEntry.entry().term() : 0)
         .withEntries(Collections.emptyList())
         .withCommitIndex(raft.getCommitIndex())
         .build();
@@ -121,11 +119,9 @@ abstract class AbstractAppender implements AutoCloseable {
     final Indexed<RaftLogEntry> prevEntry = reader.getCurrentEntry();
 
     final DefaultRaftMember leader = raft.getLeader();
-    AppendRequest.Builder builder = AppendRequest.builder()
+    AppendRequest.Builder builder = builderWithPreviousEntry(prevEntry)
         .withTerm(raft.getTerm())
         .withLeader(leader != null ? leader.memberId() : null)
-        .withPrevLogIndex(prevEntry != null ? prevEntry.index() : reader.getFirstIndex() - 1)
-        .withPrevLogTerm(prevEntry != null ? prevEntry.entry().term() : 0)
         .withCommitIndex(raft.getCommitIndex());
 
     // Build a list of entries to send to the member.
@@ -152,6 +148,26 @@ abstract class AbstractAppender implements AutoCloseable {
 
     // Add the entries to the request builder and build the request.
     return builder.withEntries(entries).build();
+  }
+
+  private AppendRequest.Builder builderWithPreviousEntry(Indexed<RaftLogEntry> prevEntry) {
+    long prevIndex = 0;
+    long prevTerm = 0;
+
+    if (prevEntry != null) {
+      prevIndex = prevEntry.index();
+      prevTerm = prevEntry.entry().term();
+    }
+    else {
+      final Snapshot currentSnapshot = raft.getSnapshotStore().getCurrentSnapshot();
+      if (currentSnapshot != null) {
+        prevIndex = currentSnapshot.index();
+        prevTerm = currentSnapshot.term();
+      }
+    }
+    return AppendRequest.builder()
+        .withPrevLogTerm(prevTerm)
+        .withPrevLogIndex(prevIndex);
   }
 
   /**
@@ -309,6 +325,10 @@ abstract class AbstractAppender implements AutoCloseable {
    */
   protected void resetNextIndex(RaftMemberContext member, AppendResponse response) {
     long nextIndex = response.lastLogIndex() + 1;
+    resetNextIndex(member, nextIndex);
+  }
+
+  private void resetNextIndex(RaftMemberContext member, long nextIndex) {
     if (member.getLogReader().getNextIndex() != nextIndex) {
       member.getLogReader().reset(nextIndex);
       log.trace("Reset next index for {} to {}", member, nextIndex);
@@ -441,6 +461,7 @@ abstract class AbstractAppender implements AutoCloseable {
             .withTerm(raft.getTerm())
             .withLeader(leader != null ? leader.memberId() : null)
             .withIndex(snapshot.index())
+            .withSnapshotTerm(snapshot.term())
             .withTimestamp(snapshot.timestamp().unixTimestamp())
             .withVersion(snapshot.version())
             .withOffset(member.getNextSnapshotOffset())
@@ -519,6 +540,7 @@ abstract class AbstractAppender implements AutoCloseable {
       member.setNextSnapshotIndex(0);
       member.setNextSnapshotOffset(0);
       member.setSnapshotIndex(request.snapshotIndex());
+      resetNextIndex(member, request.snapshotIndex() + 1);
     }
     // If more install requests remain, increment the member's snapshot offset.
     else {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/PassiveRole.java
@@ -146,56 +146,70 @@ public class PassiveRole extends InactiveRole {
    */
   protected boolean checkPreviousEntry(AppendRequest request, CompletableFuture<AppendResponse> future) {
     RaftLogWriter writer = raft.getLogWriter();
-    RaftLogReader reader = raft.getLogReader();
 
     // If the previous term is set, validate that it matches the local log.
     // We check the previous log term since that indicates whether any entry is present in the leader's
-    // log at the previous log index. It's possible that the leader can send a non-zero previous log index
-    // with a zero term in the event the leader has compacted its logs and is sending the first entry.
+    // log at the previous log index. prevLogTerm is 0 only when it is the first entry of the log.
     if (request.prevLogTerm() != 0) {
       // Get the last entry written to the log.
       Indexed<RaftLogEntry> lastEntry = writer.getLastEntry();
 
       // If the local log is non-empty...
       if (lastEntry != null) {
-        // If the previous log index is greater than the last entry index, fail the attempt.
-        if (request.prevLogIndex() > lastEntry.index()) {
-          log.debug("Rejected {}: Previous index ({}) is greater than the local log's last index ({})", request, request.prevLogIndex(), lastEntry.index());
-          return failAppend(lastEntry.index(), future);
-        }
-
-        // If the previous log index is less than the last written entry index, look up the entry.
-        if (request.prevLogIndex() < lastEntry.index()) {
-          // Reset the reader to the previous log index.
-          if (reader.getNextIndex() != request.prevLogIndex()) {
-            reader.reset(request.prevLogIndex());
-          }
-
-          // The previous entry should exist in the log if we've gotten this far.
-          if (!reader.hasNext()) {
-            log.debug("Rejected {}: Previous entry does not exist in the local log", request);
-            return failAppend(lastEntry.index(), future);
-          }
-
-          // Read the previous entry and validate that the term matches the request previous log term.
-          Indexed<RaftLogEntry> previousEntry = reader.next();
-          if (request.prevLogTerm() != previousEntry.entry().term()) {
-            log.debug("Rejected {}: Previous entry term ({}) does not match local log's term for the same entry ({})", request, request.prevLogTerm(), previousEntry.entry().term());
-            return failAppend(request.prevLogIndex() - 1, future);
-          }
-        }
-        // If the previous log term doesn't equal the last entry term, fail the append, sending the prior entry.
-        else if (request.prevLogTerm() != lastEntry.entry().term()) {
-          log.debug("Rejected {}: Previous entry term ({}) does not equal the local log's last term ({})", request, request.prevLogTerm(), lastEntry.entry().term());
-          return failAppend(request.prevLogIndex() - 1, future);
-        }
+        return checkPreviousEntry(request, lastEntry.index(), lastEntry.entry().term(), future);
       } else {
-        // If the previous log index is set and the last entry is null, fail the append.
-        if (request.prevLogIndex() > 0) {
-          log.debug("Rejected {}: Previous index ({}) is greater than the local log's last index (0)", request, request.prevLogIndex());
-          return failAppend(0, future);
+        final Snapshot currentSnapshot = raft.getSnapshotStore().getCurrentSnapshot();
+        if (currentSnapshot != null) {
+          return checkPreviousEntry(request, currentSnapshot.index(), currentSnapshot.term(), future);
+        } else {
+          // If the previous log index is set and the last entry is null and there is no snapshot, fail the append.
+          if (request.prevLogIndex() > 0) {
+            log.debug(
+                "Rejected {}: Previous index ({}) is greater than the local log's last index (0)",
+                request,
+                request.prevLogIndex());
+            return failAppend(0, future);
+          }
         }
       }
+    }
+    return true;
+  }
+
+  private boolean checkPreviousEntry(AppendRequest request, long lastEntryIndex, long lastEntryTerm, CompletableFuture<AppendResponse> future) {
+
+    RaftLogReader reader = raft.getLogReader();
+
+    // If the previous log index is greater than the last entry index, fail the attempt.
+    if (request.prevLogIndex() > lastEntryIndex) {
+      log.debug("Rejected {}: Previous index ({}) is greater than the local log's last index ({})", request, request.prevLogIndex(), lastEntryIndex);
+      return failAppend(lastEntryIndex, future);
+    }
+
+    // If the previous log index is less than the last written entry index, look up the entry.
+    if (request.prevLogIndex() < lastEntryIndex) {
+      // Reset the reader to the previous log index.
+      if (reader.getNextIndex() != request.prevLogIndex()) {
+        reader.reset(request.prevLogIndex());
+      }
+
+      // The previous entry should exist in the log if we've gotten this far.
+      if (!reader.hasNext()) {
+        log.debug("Rejected {}: Previous entry does not exist in the local log", request);
+        return failAppend(lastEntryIndex, future);
+      }
+
+      // Read the previous entry and validate that the term matches the request previous log term.
+      Indexed<RaftLogEntry> previousEntry = reader.next();
+      if (request.prevLogTerm() != previousEntry.entry().term()) {
+        log.debug("Rejected {}: Previous entry term ({}) does not match local log's term for the same entry ({})", request, request.prevLogTerm(), previousEntry.entry().term());
+        return failAppend(request.prevLogIndex() - 1, future);
+      }
+    }
+    // If the previous log term doesn't equal the last entry term, fail the append, sending the prior entry.
+    else if (request.prevLogTerm() != lastEntryTerm) {
+      log.debug("Rejected {}: Previous entry term ({}) does not equal the local log's last term ({})", request, request.prevLogTerm(), lastEntryTerm);
+      return failAppend(request.prevLogIndex() - 1, future);
     }
     return true;
   }
@@ -555,6 +569,7 @@ public class PassiveRole extends InactiveRole {
 
       Snapshot snapshot = raft.getSnapshotStore().newTemporarySnapshot(
           request.snapshotIndex(),
+          request.snapshotTerm(),
           WallClockTimestamp.from(request.snapshotTimestamp()));
       pendingSnapshot = new PendingSnapshot(snapshot);
     }
@@ -580,9 +595,14 @@ public class PassiveRole extends InactiveRole {
 
     // If the snapshot is complete, store the snapshot and reset state, otherwise update the next snapshot offset.
     if (request.complete()) {
-      log.debug("Committing snapshot {}", pendingSnapshot.snapshot().index());
+      final long index = pendingSnapshot.snapshot().index();
+      log.debug("Committing snapshot {}", index);
       pendingSnapshot.commit();
       pendingSnapshot = null;
+      // Throw away existing log if it is not up-to-date with the snapshot index.
+      if (raft.getLogWriter().getLastIndex() < index) {
+        raft.getLogWriter().reset(index + 1);
+      }
     } else {
       pendingSnapshot.incrementOffset();
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
@@ -57,7 +57,7 @@ final class MemorySnapshot extends Snapshot {
   @Override
   public Snapshot persist() {
     if (store.storage.storageLevel() != StorageLevel.MEMORY) {
-      try (Snapshot newSnapshot = store.newSnapshot(index(), timestamp())) {
+      try (Snapshot newSnapshot = store.newSnapshot(index(), term(), timestamp())) {
         try (SnapshotWriter newSnapshotWriter = newSnapshot.openWriter()) {
           buffer.flip().skip(SnapshotDescriptor.BYTES);
           newSnapshotWriter.write(buffer.array(), buffer.position(), buffer.remaining());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -75,6 +75,10 @@ public abstract class Snapshot implements AutoCloseable {
     return descriptor.index();
   }
 
+  public long term() {
+    return descriptor.term();
+  }
+
   /**
    * Returns the snapshot timestamp.
    * <p>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptor.java
@@ -30,7 +30,23 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 public final class SnapshotDescriptor implements AutoCloseable {
   public static final int BYTES = 64;
-  public static final int VERSION = 1;
+
+  // Current snapshot version.
+  private static final int VERSION = 1;
+
+  // The lengths of each field in the header.
+  private static final int INDEX_LENGTH = Long.BYTES;          // 64-bit signed integer
+  private static final int TIMESTAMP_LENGTH = Long.BYTES;      // 64-bit signed integer
+  private static final int VERSION_LENGTH = Integer.BYTES;     // 32-bit signed integer
+  private static final int LOCKED_LENGTH = 1;                  // 8-bit signed byte
+  private static final int TERM_LENGTH = Long.BYTES;           // 64-bit signed integer
+
+  // The positions of each field in the header.
+  private static final int INDEX_POSITION = 0;                                           // 0
+  private static final int TIMESTAMP_POSITION = INDEX_POSITION + INDEX_LENGTH;           // 8
+  private static final int VERSION_POSITION = TIMESTAMP_POSITION + TIMESTAMP_LENGTH;     // 16
+  private static final int LOCKED_POSITION = VERSION_POSITION + VERSION_LENGTH;          // 20
+  private static final int TERM_POSITION = LOCKED_POSITION + LOCKED_LENGTH;              // 21
 
   /**
    * Returns a descriptor builder.
@@ -57,6 +73,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
   private Buffer buffer;
   private final long index;
   private final long timestamp;
+  private final long term;
   private boolean locked;
   private int version;
 
@@ -69,6 +86,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
     this.timestamp = buffer.readLong();
     this.version = buffer.readInt();
     this.locked = buffer.readBoolean();
+    this.term = buffer.readLong();
     buffer.skip(BYTES - buffer.position());
   }
 
@@ -99,6 +117,10 @@ public final class SnapshotDescriptor implements AutoCloseable {
     return version;
   }
 
+  public long term() {
+    return term;
+  }
+
   /**
    * Returns whether the snapshot has been locked by commitment.
    * <p>
@@ -115,7 +137,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
    */
   public void lock() {
     buffer.flush()
-        .writeBoolean(20, true)
+        .writeBoolean(LOCKED_POSITION, true)
         .flush();
     locked = true;
   }
@@ -129,6 +151,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
         .writeLong(timestamp)
         .writeInt(version)
         .writeBoolean(locked)
+        .writeLong(term)
         .skip(BYTES - buffer.position())
         .flush();
     return this;
@@ -165,7 +188,12 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withIndex(long index) {
-      buffer.writeLong(0, index);
+      buffer.writeLong(INDEX_POSITION, index);
+      return this;
+    }
+
+    public Builder withTerm(long term) {
+      buffer.writeLong(TERM_POSITION, term);
       return this;
     }
 
@@ -176,7 +204,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The snapshot builder.
      */
     public Builder withTimestamp(long timestamp) {
-      buffer.writeLong(8, timestamp);
+      buffer.writeLong(TIMESTAMP_POSITION, timestamp);
       return this;
     }
 
@@ -186,7 +214,7 @@ public final class SnapshotDescriptor implements AutoCloseable {
      * @return The built snapshot descriptor.
      */
     public SnapshotDescriptor build() {
-      return new SnapshotDescriptor(buffer.writeInt(16, VERSION));
+      return new SnapshotDescriptor(buffer.writeInt(VERSION_POSITION, VERSION));
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -163,9 +163,10 @@ public class SnapshotStore implements AutoCloseable {
    * @param timestamp The snapshot timestamp.
    * @return The snapshot.
    */
-  public Snapshot newTemporarySnapshot(long index, WallClockTimestamp timestamp) {
+  public Snapshot newTemporarySnapshot(long index, long term, WallClockTimestamp timestamp) {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(index)
+        .withTerm(term)
         .withTimestamp(timestamp.unixTimestamp())
         .build();
     return newSnapshot(descriptor, StorageLevel.MEMORY);
@@ -178,9 +179,10 @@ public class SnapshotStore implements AutoCloseable {
    * @param timestamp The snapshot timestamp.
    * @return The snapshot.
    */
-  public Snapshot newSnapshot(long index, WallClockTimestamp timestamp) {
+  public Snapshot newSnapshot(long index, long term, WallClockTimestamp timestamp) {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(index)
+        .withTerm(term)
         .withTimestamp(timestamp.unixTimestamp())
         .build();
     return newSnapshot(descriptor, storage.storageLevel());

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/AbstractSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/AbstractSnapshotStoreTest.java
@@ -40,7 +40,7 @@ public abstract class AbstractSnapshotStoreTest {
   public void testWriteSnapshotChunks() {
     SnapshotStore store = createSnapshotStore();
     WallClockTimestamp timestamp = new WallClockTimestamp();
-    Snapshot snapshot = store.newSnapshot(2, timestamp);
+    Snapshot snapshot = store.newSnapshot(2, 1, timestamp);
     assertEquals(2, snapshot.index());
     assertEquals(timestamp, snapshot.timestamp());
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -64,7 +64,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testStoreLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newSnapshot(2, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(2, 3, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
@@ -75,6 +75,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     store = createSnapshotStore();
     assertNotNull(store.getSnapshot(2));
     assertEquals(2, store.getSnapshot(2).index());
+    assertEquals(3, store.getSnapshot(2).term());
 
     try (SnapshotReader reader = snapshot.openReader()) {
       assertEquals(10, reader.readLong());
@@ -88,7 +89,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testPersistLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newTemporarySnapshot(2, new WallClockTimestamp());
+    Snapshot snapshot = store.newTemporarySnapshot(2, 3, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
@@ -111,6 +112,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     store = createSnapshotStore();
     assertNotNull(store.getSnapshot(2));
     assertEquals(2, store.getSnapshot(2).index());
+    assertEquals(3, store.getSnapshot(2).term());
 
     snapshot = store.getSnapshot(2);
     try (SnapshotReader reader = snapshot.openReader()) {
@@ -125,7 +127,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testStreamSnapshot() throws Exception {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newSnapshot(1, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(1, 1, new WallClockTimestamp());
     for (long i = 1; i <= 10; i++) {
       try (SnapshotWriter writer = snapshot.openWriter()) {
         writer.writeLong(i);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/SnapshotDescriptorTest.java
@@ -31,9 +31,11 @@ public class SnapshotDescriptorTest {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(2)
         .withTimestamp(3)
+        .withTerm(4)
         .build();
     assertEquals(2, descriptor.index());
     assertEquals(3, descriptor.timestamp());
+    assertEquals(4, descriptor.term());
     assertEquals(1, descriptor.version());
   }
 
@@ -42,6 +44,7 @@ public class SnapshotDescriptorTest {
     SnapshotDescriptor descriptor = SnapshotDescriptor.builder()
         .withIndex(2)
         .withTimestamp(3)
+        .withTerm(4)
         .build();
     Buffer buffer = HeapBuffer.allocate(SnapshotDescriptor.BYTES);
     descriptor.copyTo(buffer);
@@ -49,6 +52,7 @@ public class SnapshotDescriptorTest {
     descriptor = new SnapshotDescriptor(buffer);
     assertEquals(2, descriptor.index());
     assertEquals(3, descriptor.timestamp());
+    assertEquals(4, descriptor.term());
     assertEquals(1, descriptor.version());
   }
 


### PR DESCRIPTION
 * previous term is 0 only for the first entry in the log
 * if there is no previous entry in the log after compaction, use the existing snapshot as previous entry.
 * reset follower's next index when install response is success
 * reset log after receiving a snapshot from leader

closes #17