### PR TITLE
fix(raft): fixes issues with concurrent snapshot writers

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -44,6 +44,7 @@ import io.atomix.protocols.raft.storage.snapshot.SnapshotReader;
 import io.atomix.protocols.raft.storage.snapshot.SnapshotWriter;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.AtomixIOException;
 import io.atomix.utils.concurrent.ComposableFuture;
 import io.atomix.utils.concurrent.Futures;
 import io.atomix.utils.concurrent.OrderedFuture;
@@ -208,7 +209,7 @@ public class RaftServiceManager implements AutoCloseable {
       // Wait for snapshots in all state machines to be completed before compacting the log at the last applied index.
       takeSnapshots().whenComplete((snapshot, error) -> {
         if (error == null) {
-          scheduleCompletion(snapshot.persist());
+          scheduleCompletion(snapshot);
         }
       });
 
@@ -253,7 +254,19 @@ public class RaftServiceManager implements AutoCloseable {
     stateContext.schedule(SNAPSHOT_COMPLETION_DELAY, () -> {
       if (completeSnapshot(snapshot.index())) {
         logger.debug("Completing snapshot {}", snapshot.index());
-        snapshot.complete();
+        try {
+          snapshot.complete();
+        } catch (AtomixIOException e) {
+          logger.error("Failed to complete snapshot {}, rescheduling completion", snapshot, e);
+          scheduleCompletion(snapshot);
+          return;
+        } catch (Exception e) {
+          logger.error("Failed to complete snapshot {}, rescheduling snapshots", snapshot, e);
+          snapshot.close();
+          scheduleSnapshots();
+          return;
+        }
+
         // If log compaction is being forced, immediately compact the logs.
         if (!raft.getLoadMonitor().isUnderHighLoad() || isRunningOutOfDiskSpace() || isRunningOutOfMemory()) {
           compactLogs(snapshot.index());
@@ -453,7 +466,7 @@ public class RaftServiceManager implements AutoCloseable {
    * Takes snapshots for the given index.
    */
   Snapshot snapshot() {
-    Snapshot snapshot = raft.getSnapshotStore().newTemporarySnapshot(raft.getLastApplied(), raft.getLastAppliedTerm(), new WallClockTimestamp());
+    Snapshot snapshot = raft.getSnapshotStore().newSnapshot(raft.getLastApplied(), raft.getLastAppliedTerm(), new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       for (RaftServiceContext service : raft.getServices()) {
         writer.buffer().mark();

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshot.java
@@ -17,10 +17,12 @@ package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.FileBuffer;
+import io.atomix.utils.AtomixIOException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -42,7 +44,9 @@ final class FileSnapshot extends Snapshot {
   @Override
   public synchronized SnapshotWriter openWriter() {
     checkWriter();
-    Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES);
+    checkState(!file.file().exists(), "cannot write to completed snapshot");
+    checkNotNull(file.temporaryFile(), "missing temporary snapshot file for writing");
+    Buffer buffer = FileBuffer.allocate(file.temporaryFile(), SnapshotDescriptor.BYTES);
     descriptor.copyTo(buffer);
 
     int length = buffer.position(SnapshotDescriptor.BYTES).readInt();
@@ -66,17 +70,36 @@ final class FileSnapshot extends Snapshot {
   }
 
   @Override
-  public boolean isPersisted() {
-    return true;
-  }
-
-  @Override
   public Snapshot complete() {
-    Buffer buffer = FileBuffer.allocate(file.file(), SnapshotDescriptor.BYTES);
+    checkNotNull(file.temporaryFile(), "no temporary snapshot file to read from");
+
+    Buffer buffer = FileBuffer.allocate(file.temporaryFile(), SnapshotDescriptor.BYTES);
     try (SnapshotDescriptor descriptor = new SnapshotDescriptor(buffer)) {
       descriptor.lock();
     }
+
+    try {
+      Files.move(file.temporaryFile().toPath(), file.file().toPath());
+    } catch (FileAlreadyExistsException e) {
+      LOGGER.debug("Snapshot {} was already previously completed", this);
+    } catch (IOException e) {
+      throw new AtomixIOException(e);
+    }
+
+    file.clearTemporaryFile();
     return super.complete();
+  }
+
+  /**
+   * Deletes the temporary file
+   */
+  @Override
+  public void close() {
+    super.close();
+
+    if (file.temporaryFile() != null) {
+      deleteFileSilently(file.temporaryFile().toPath());
+    }
   }
 
   /**
@@ -86,11 +109,17 @@ final class FileSnapshot extends Snapshot {
   public void delete() {
     LOGGER.debug("Deleting {}", this);
     Path path = file.file().toPath();
+
     if (Files.exists(path)) {
-      try {
-        Files.delete(file.file().toPath());
-      } catch (IOException e) {
-      }
+      deleteFileSilently(path);
+    }
+  }
+
+  private void deleteFileSilently(Path path) {
+    try {
+      Files.delete(path);
+    } catch (IOException e) {
+      LOGGER.debug("Failed to delete snapshot file {}", path, e);
     }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/MemorySnapshot.java
@@ -15,7 +15,6 @@
  */
 package io.atomix.protocols.raft.storage.snapshot;
 
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.buffer.HeapBuffer;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -26,7 +25,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 final class MemorySnapshot extends Snapshot {
   private final HeapBuffer buffer;
   private final SnapshotDescriptor descriptor;
-  private final SnapshotStore store;
 
   MemorySnapshot(HeapBuffer buffer, SnapshotDescriptor descriptor, SnapshotStore store) {
     super(descriptor, store);
@@ -34,7 +32,6 @@ final class MemorySnapshot extends Snapshot {
     this.buffer = checkNotNull(buffer, "buffer cannot be null");
     this.buffer.position(SnapshotDescriptor.BYTES).mark();
     this.descriptor = checkNotNull(descriptor, "descriptor cannot be null");
-    this.store = checkNotNull(store, "store cannot be null");
   }
 
   @Override
@@ -52,25 +49,6 @@ final class MemorySnapshot extends Snapshot {
   @Override
   public synchronized SnapshotReader openReader() {
     return openReader(new SnapshotReader(buffer.reset().slice(), this), descriptor);
-  }
-
-  @Override
-  public Snapshot persist() {
-    if (store.storage.storageLevel() != StorageLevel.MEMORY) {
-      try (Snapshot newSnapshot = store.newSnapshot(index(), term(), timestamp())) {
-        try (SnapshotWriter newSnapshotWriter = newSnapshot.openWriter()) {
-          buffer.flip().skip(SnapshotDescriptor.BYTES);
-          newSnapshotWriter.write(buffer.array(), buffer.position(), buffer.remaining());
-        }
-        return newSnapshot;
-      }
-    }
-    return this;
-  }
-
-  @Override
-  public boolean isPersisted() {
-    return store.storage.storageLevel() == StorageLevel.MEMORY;
   }
 
   @Override

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/Snapshot.java
@@ -16,7 +16,6 @@
 package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.utils.time.WallClockTimestamp;
-
 import java.util.Objects;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -75,6 +74,13 @@ public abstract class Snapshot implements AutoCloseable {
     return descriptor.index();
   }
 
+  /**
+   * Returns the snapshot term.
+   *
+   * The snapshot term is the term of the state machine at the point at which the snapshot was written.
+   *
+   * @return The snapshot term.
+   */
   public long term() {
     return descriptor.term();
   }
@@ -178,24 +184,6 @@ public abstract class Snapshot implements AutoCloseable {
   }
 
   /**
-   * Persists the snapshot to disk if necessary.
-   * <p>
-   * If the snapshot store is backed by disk, the snapshot will be persisted.
-   *
-   * @return The persisted snapshot.
-   */
-  public Snapshot persist() {
-    return this;
-  }
-
-  /**
-   * Returns whether the snapshot is persisted.
-   *
-   * @return Whether the snapshot is persisted.
-   */
-  public abstract boolean isPersisted();
-
-  /**
    * Closes the snapshot.
    */
   @Override
@@ -206,6 +194,7 @@ public abstract class Snapshot implements AutoCloseable {
    * Deletes the snapshot.
    */
   public void delete() {
+
   }
 
   @Override
@@ -219,13 +208,14 @@ public abstract class Snapshot implements AutoCloseable {
       return false;
     }
     Snapshot snapshot = (Snapshot) object;
-    return snapshot.index() == index();
+    return snapshot.index() == index() && snapshot.term() == term();
   }
 
   @Override
   public String toString() {
     return toStringHelper(this)
         .add("index", index())
+        .add("term", term())
         .toString();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotFile.java
@@ -16,8 +16,10 @@
 package io.atomix.protocols.raft.storage.snapshot;
 
 import com.google.common.annotations.VisibleForTesting;
+import io.atomix.utils.AtomixIOException;
 
 import java.io.File;
+import java.io.IOException;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -29,6 +31,7 @@ public final class SnapshotFile {
   private static final char EXTENSION_SEPARATOR = '.';
   private static final String EXTENSION = "snapshot";
   private final File file;
+  private File temporaryFile;
 
   /**
    * Returns a boolean value indicating whether the given file appears to be a parsable snapshot file.
@@ -91,6 +94,19 @@ public final class SnapshotFile {
   }
 
   /**
+   * Creates a temporary file for writing snapshots.
+   */
+  static File createTemporaryFile(File base) {
+    try {
+      final File file = File.createTempFile(base.getName(), null);
+      file.deleteOnExit();
+      return file;
+    } catch (IOException e) {
+      throw new AtomixIOException(e);
+    }
+  }
+
+  /**
    * Creates a snapshot file name from the given parameters.
    */
   @VisibleForTesting
@@ -102,10 +118,29 @@ public final class SnapshotFile {
   }
 
   /**
-   * @throws IllegalArgumentException if {@code file} is not a valid snapshot file
+   * Creates a new SnapshotFile with references to a permanent snapshot file (for reading)
+   * and a temporary snapshot file (for writing). The temporary file can be null if the snapshot
+   * is already completed and should not be written to.
+   *
+   * @param file the snapshot file which is used for reading
+   * @param temporaryFile the snapshot file which is used for writing
    */
-  SnapshotFile(File file) {
+  SnapshotFile(File file, File temporaryFile) {
     this.file = file;
+    this.temporaryFile = temporaryFile;
+  }
+
+  /**
+   * Returns the snapshot lock file name.
+   *
+   * @return the snapshot lock file name
+   */
+  File temporaryFile() {
+    return temporaryFile;
+  }
+
+  void clearTemporaryFile() {
+    temporaryFile = null;
   }
 
   /**
@@ -130,5 +165,4 @@ public final class SnapshotFile {
   static String parseName(String fileName) {
     return fileName.substring(0, fileName.lastIndexOf(PART_SEPARATOR, fileName.lastIndexOf(PART_SEPARATOR) - 1));
   }
-
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -129,7 +129,7 @@ public class RaftServiceManagerTest {
     assertEquals(2, snapshot.index());
     assertTrue(snapshotTaken.get());
 
-    snapshot = snapshot.persist().complete();
+    snapshot = snapshot.complete();
 
     assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
 
@@ -161,7 +161,7 @@ public class RaftServiceManagerTest {
     assertEquals(2, snapshot.index());
     assertTrue(snapshotTaken.get());
 
-    snapshot.persist().complete();
+    snapshot.complete();
 
     assertEquals(2, raft.getSnapshotStore().getCurrentSnapshot().index());
 

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/storage/snapshot/FileSnapshotStoreTest.java
@@ -24,21 +24,20 @@ import org.junit.Test;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.FileVisitResult;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.Files;
+import java.nio.file.FileVisitResult;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
 
 /**
- * File snapshot store test.
+ * Snapshot store test.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
@@ -89,17 +88,12 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
   public void testPersistLoadSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
-    Snapshot snapshot = store.newTemporarySnapshot(2, 3, new WallClockTimestamp());
+    Snapshot snapshot = store.newSnapshot(2, 3, new WallClockTimestamp());
     try (SnapshotWriter writer = snapshot.openWriter()) {
       writer.writeLong(10);
     }
 
-    snapshot = snapshot.persist();
-
-    assertTrue(snapshot.isPersisted());
-
     assertNull(store.getSnapshot(2));
-
     snapshot.complete();
     assertNotNull(store.getSnapshot(2));
 
@@ -112,7 +106,6 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     store = createSnapshotStore();
     assertNotNull(store.getSnapshot(2));
     assertEquals(2, store.getSnapshot(2).index());
-    assertEquals(3, store.getSnapshot(2).term());
 
     snapshot = store.getSnapshot(2);
     try (SnapshotReader reader = snapshot.openReader()) {
@@ -124,7 +117,7 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
    * Tests writing multiple times to a snapshot designed to mimic chunked snapshots from leaders.
    */
   @Test
-  public void testStreamSnapshot() throws Exception {
+  public void testStreamSnapshot() {
     SnapshotStore store = createSnapshotStore();
 
     Snapshot snapshot = store.newSnapshot(1, 1, new WallClockTimestamp());
@@ -141,6 +134,39 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
         assertEquals(i, reader.readLong());
       }
     }
+  }
+
+  /**
+   * Tests case where two {@link FileSnapshot} instances are trying to write the same snapshot
+   */
+  @Test
+  public void testConcurrentSnapshotWriters() {
+    SnapshotStore store = createSnapshotStore();
+    final WallClockTimestamp timestamp = new WallClockTimestamp();
+    Snapshot first = store.newSnapshot(1, 1, timestamp);
+    Snapshot second = store.newSnapshot(1, 1, timestamp);
+
+    try (SnapshotWriter firstWriter = first.openWriter()) {
+      firstWriter.writeLong(1);
+    }
+
+    try (SnapshotWriter secondWriter = second.openWriter()) {
+      secondWriter.writeLong(1);
+    }
+
+    first.complete();
+    second.complete();
+
+    Snapshot completed = store.getSnapshot(first.index());
+    assertNotNull(completed);
+    long result = 0;
+    try (SnapshotReader reader = completed.openReader()) {
+      while (reader.hasRemaining()) {
+        result += reader.readLong();
+      }
+    }
+
+    assertEquals(result, 1);
   }
 
   @Before
@@ -164,5 +190,4 @@ public class FileSnapshotStoreTest extends AbstractSnapshotStoreTest {
     }
     testId = UUID.randomUUID().toString();
   }
-
 }


### PR DESCRIPTION
- file snapshots are now written to a temporary file and moved to a permanent deterministic location on completion from which they are read

closes #20 