### PR TITLE
chore(raft/zeebe): expose standalone building blocks

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -23,6 +23,8 @@ import io.atomix.primitive.service.PrimitiveService;
 import io.atomix.protocols.raft.cluster.RaftCluster;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.impl.DefaultRaftServer;
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.protocols.raft.impl.RaftServiceManager;
 import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.protocols.raft.storage.log.RaftLog;
@@ -530,6 +532,13 @@ public interface RaftServer {
   CompletableFuture<Void> leave();
 
   /**
+   * Returns the current Raft context.
+   *
+   * @return the current Raft context
+   */
+  RaftContext getContext();
+
+  /**
    * Builds a single-use Raft server.
    * <p>
    * This builder should be used to programmatically configure and construct a new {@link RaftServer} instance.
@@ -580,6 +589,7 @@ public interface RaftServer {
     protected ThreadModel threadModel = DEFAULT_THREAD_MODEL;
     protected int threadPoolSize = DEFAULT_THREAD_POOL_SIZE;
     protected ThreadContextFactory threadContextFactory;
+    protected RaftStateMachineFactory stateMachineFactory = RaftServiceManager::new;
 
     protected Builder(MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -724,6 +734,18 @@ public interface RaftServer {
      */
     public Builder withThreadContextFactory(ThreadContextFactory threadContextFactory) {
       this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
+      return this;
+    }
+
+    /**
+     * Sets the server's state machine factory.
+     *
+     * @param stateMachineFactory the server state machine factory
+     * @return the server builder
+     * @throws NullPointerException if the factory is null
+     */
+    public Builder withStateMachineFactory(RaftStateMachineFactory stateMachineFactory) {
+      this.stateMachineFactory = checkNotNull(stateMachineFactory, "stateMachineFactory cannot be null");
       return this;
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftStateMachine.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftStateMachine.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft;
+
+import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.concurrent.ThreadContext;
+import java.util.concurrent.CompletableFuture;
+
+public interface RaftStateMachine extends AutoCloseable {
+
+  /**
+   * The state machine thread context; can be used to sequence operations on the state machine.
+   *
+   * @return the state machine thread context
+   */
+  ThreadContext executor();
+
+  /**
+   * Compacts Raft logs.
+   *
+   * @return a future to be completed once logs have been compacted
+   */
+  CompletableFuture<Void> compact();
+
+  /**
+   * Applies all commits up to the given index.
+   * <p>
+   * Calls to this method are assumed not to expect a result. This allows some optimizations to be made internally since
+   * linearizable events don't have to be waited to complete the command.
+   *
+   * @param index The index up to which to apply commits.
+   */
+  void applyAll(long index);
+
+  /**
+   * Applies the entry at the given index to the state machine.
+   * <p>
+   * Calls to this method are assumed to expect a result. This means linearizable session events triggered by the
+   * application of the command at the given index will be awaited before completing the returned future.
+   *
+   * @param index The index to apply.
+   * @return A completable future to be completed once the commit has been applied.
+   */
+  <T> CompletableFuture<T> apply(long index);
+
+  /**
+   * Applies an entry to the state machine.
+   * <p>
+   * Calls to this method are assumed to expect a result. This means linearizable session events triggered by the
+   * application of the given entry will be awaited before completing the returned future.
+   *
+   * @param entry The entry to apply.
+   * @return A completable future to be completed with the result.
+   */
+  <T> CompletableFuture<T> apply(Indexed<? extends RaftLogEntry> entry);
+
+  /**
+   * Close any opened resources; note however that the thread context should NOT be closed, as it is
+   * managed by the Raft server.
+   */
+  @Override
+  void close();
+
+  /**
+   * Updates the compactable position; by default does nothing as the default behaviour is to use
+   * the last applied index and term.
+   * @param index index up to which the log can be compacted
+   * @param term term of the entry with that index, used when snapshotting
+   */
+  default void setCompactablePosition(long index, long term) {
+
+  }
+
+  /**
+   * Returns the current compactable index.
+   *
+   * @return the current compactable index
+   */
+  long getCompactableIndex();
+
+  /**
+   * Returns the term of the entry with the current compactable index.
+   *
+   * @return the term of the entry with the current compactable index
+   */
+  long getCompactableTerm();
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftStateMachineFactory.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftStateMachineFactory.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft;
+
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
+
+@FunctionalInterface
+public interface RaftStateMachineFactory {
+  RaftStateMachine createStateMachine(
+      final RaftContext raft,
+      final ThreadContext stateContext,
+      final ThreadContextFactory threadContextFactory);
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -222,6 +222,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public RaftContext getContext() {
+    return context;
+  }
+
+  @Override
   public String toString() {
     return toStringHelper(this)
         .add("name", name())
@@ -278,7 +283,8 @@ public class DefaultRaftServer implements RaftServer {
           storage,
           primitiveTypes,
           threadContextFactory,
-          closeOnStop);
+          closeOnStop,
+          stateMachineFactory);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setSessionTimeout(sessionTimeout);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -91,6 +91,10 @@ public class RaftPartition implements Partition {
     return server != null ? server.getRole() : null;
   }
 
+  public RaftPartitionServer getServer() {
+    return server;
+  }
+
   public void addRoleChangeListener(Consumer<Role> listener) {
     if (server == null) {
       deferredRoleChangeListeners.add(listener);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartitionGroupConfig.java
@@ -18,6 +18,8 @@ package io.atomix.protocols.raft.partition;
 import io.atomix.primitive.partition.PartitionGroup;
 import io.atomix.primitive.partition.PartitionGroupConfig;
 
+import io.atomix.protocols.raft.RaftStateMachineFactory;
+import io.atomix.protocols.raft.impl.RaftServiceManager;
 import java.time.Duration;
 import java.util.HashSet;
 import java.util.Set;
@@ -187,5 +189,14 @@ public class RaftPartitionGroupConfig extends PartitionGroupConfig<RaftPartition
   public RaftPartitionGroupConfig setCompactionConfig(RaftCompactionConfig compactionConfig) {
     this.compactionConfig = compactionConfig;
     return this;
+  }
+
+  /**
+   * Returns the raft state machine factory.
+   *
+   * @return the raft state machine factory
+   */
+  public RaftStateMachineFactory getStateMachineFactory() {
+    return RaftServiceManager::new;
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
@@ -69,6 +69,7 @@ import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
 import io.atomix.protocols.raft.storage.system.Configuration;
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
 
@@ -150,6 +151,7 @@ public final class RaftNamespaces {
       .register(RaftMember.Type.class)
       .register(Instant.class)
       .register(Configuration.class)
+      .register(ZeebeEntry.class)
       .build("RaftProtocol");
 
   /**
@@ -177,6 +179,7 @@ public final class RaftNamespaces {
       .register(RaftMember.Type.class)
       .register(Instant.class)
       .register(Configuration.class)
+      .register(ZeebeEntry.class)
       .build("RaftStorage");
 
   private RaftNamespaces() {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -61,7 +61,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
   @Override
   public RaftLogReader openReader(long index, RaftLogReader.Mode mode) {
-    return new RaftLogReader(journal.openReader(index), this, mode);
+    return new RaftLogReader(journal.openReader(index, mode), this, mode);
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeEntry.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe;
+
+import io.atomix.protocols.raft.storage.log.entry.TimestampedEntry;
+
+/**
+ * Stores a free-form entry.
+ * <p>
+ * Each entry is written with the leader's {@link #timestamp() timestamp} at the time the entry was logged
+ * This gives state machines an approximation of time with which to react to the application of entries to the
+ * state machine.
+ */
+public class ZeebeEntry extends TimestampedEntry {
+  private final byte[] data;
+
+  public ZeebeEntry(long term, long timestamp, byte[] data) {
+    super(term, timestamp);
+    this.data = data;
+  }
+
+  public byte[] getData() {
+    return data;
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe;
+
+import io.atomix.storage.journal.Indexed;
+
+import java.util.concurrent.CompletableFuture;
+
+@FunctionalInterface
+public interface ZeebeLogAppender {
+  /**
+   * Appends an entry to the local Raft log and schedules replication to each follower.
+   *
+   * @param data data to store in the entry
+   * @return a future which is completed with the indexed entry without waiting for replication
+   */
+  CompletableFuture<Indexed<ZeebeEntry>> appendEntry(byte[] data);
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -121,7 +121,7 @@ public class RaftServiceManagerTest {
         1000));
     writer.commit(2);
 
-    RaftServiceManager manager = raft.getServiceManager();
+    RaftServiceManager manager = (RaftServiceManager) raft.getServiceManager();
 
     manager.apply(2).join();
 
@@ -153,7 +153,7 @@ public class RaftServiceManagerTest {
         1000));
     writer.commit(2);
 
-    RaftServiceManager manager = raft.getServiceManager();
+    RaftServiceManager manager = (RaftServiceManager) raft.getServiceManager();
 
     manager.apply(2).join();
 
@@ -251,7 +251,8 @@ public class RaftServiceManagerTest {
         storage,
         registry,
         ThreadModel.SHARED_THREAD_POOL.factory("raft-server-test-%d", 1, LoggerFactory.getLogger(RaftServer.class)),
-        true);
+        true,
+        RaftServiceManager::new);
 
     snapshotTaken = new AtomicBoolean();
     snapshotInstalled = new AtomicBoolean();

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/ZeebeTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/ZeebeTest.java
@@ -1,0 +1,233 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import com.google.common.base.Stopwatch;
+import io.atomix.protocols.raft.partition.impl.RaftPartitionServer;
+import io.atomix.protocols.raft.zeebe.util.ZeebeTestHelper;
+import io.atomix.protocols.raft.zeebe.util.ZeebeTestNode;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.concurrent.Futures;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@RunWith(Parameterized.class)
+public class ZeebeTest {
+
+  // rough estimate of how many entries we'd need to write to fill a segment
+  // segments are configured for 1kb, and one entry takes ~20 bytes (plus some metadata I guess)
+  private static final int ENTRIES_PER_SEGMENT = (1024 / 20) + 1;
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  @Parameter(0)
+  public String name;
+
+  @Parameter(1)
+  public Collection<Function<TemporaryFolder, ZeebeTestNode>> nodeSuppliers;
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final Stopwatch stopwatch = Stopwatch.createUnstarted();
+  private Collection<ZeebeTestNode> nodes;
+  private ZeebeTestHelper helper;
+
+  @Parameters(name = "{0}")
+  public static Collection<Object[]> data() {
+    return Arrays.asList(
+        new Object[] {"single node", Collections.singleton(provideNode(1))},
+        new Object[] {
+          "three nodes", Arrays.asList(provideNode(1), provideNode(2), provideNode(3))
+        });
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    stopwatch.reset();
+    nodes = buildNodes();
+    helper = new ZeebeTestHelper(nodes);
+    start();
+
+    stopwatch.start();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (stopwatch.isRunning()) {
+      stopwatch.stop();
+    }
+
+    logger.info("Test run time: {}", stopwatch.toString());
+    stop();
+  }
+
+  private Collection<ZeebeTestNode> buildNodes() {
+    return nodeSuppliers.stream()
+        .map(supplier -> supplier.apply(temporaryFolder))
+        .collect(Collectors.toList());
+  }
+
+  @SuppressWarnings("squid:S2699") // awaitAllContain is the assert here
+  @Test
+  public void shouldAppendAndReplicate() {
+    // given
+    final int partitionId = 1;
+    final ZeebeLogAppender appender = helper.awaitLeaderAppender(partitionId);
+
+    // when
+    final Indexed<ZeebeEntry> appended = appender.appendEntry(getIntAsBytes(0)).join();
+
+    // then
+    helper.awaitAllContain(partitionId, appended);
+  }
+
+  @Test
+  public void shouldNotCompactAnything() {
+    // given
+    final int partitionId = 1;
+    final RaftPartitionServer server = helper.awaitLeaderServer(1);
+    final ZeebeLogAppender appender = helper.awaitLeaderAppender(partitionId);
+
+    // when
+    final Indexed<ZeebeEntry> firstAppended = appender.appendEntry(getIntAsBytes(0)).join();
+    for (int i = 1; i < ENTRIES_PER_SEGMENT; i++) {
+      helper.awaitAllContain(partitionId, appender.appendEntry(getIntAsBytes(i)).join());
+    }
+    server.snapshot().join();
+
+    // then
+    assertTrue(helper.containsIndexed(server, firstAppended));
+  }
+
+  @Test
+  public void shouldCompactUpToCompactablePosition() {
+    // given
+    final int partitionId = 1;
+    final RaftPartitionServer server = helper.awaitLeaderServer(1);
+    final ZeebeLogAppender appender = helper.awaitLeaderAppender(partitionId);
+
+    // when
+    Indexed<ZeebeEntry> appended = appender.appendEntry(getIntAsBytes(0)).join();
+    final Indexed<ZeebeEntry> firstAppended = appended;
+    for (int i = 1; i < ENTRIES_PER_SEGMENT; i++) {
+      appended = appender.appendEntry(getIntAsBytes(i)).join();
+      helper.awaitAllContain(partitionId, appended);
+    }
+    server.setCompactablePosition(appended.index(), appended.entry().term());
+    server.snapshot().join();
+
+    // then
+    assertFalse(helper.containsIndexed(server, firstAppended));
+    assertTrue(helper.containsIndexed(server, appended));
+  }
+
+  @Test
+  public void shouldFailover() {
+    assumeTrue(nodes.size() > 1);
+
+    // given
+    final int partitionId = 1;
+    final ZeebeTestNode originalLeader = helper.awaitLeader(partitionId);
+
+    // when
+    originalLeader.stop().join();
+    originalLeader.start(nodes).join();
+
+    // then
+    assertTrue(nodes.size() == 1 || !originalLeader.equals(helper.awaitLeader(partitionId)));
+  }
+
+  @SuppressWarnings("squid:S2699") // awaitAllContain is the assert here
+  @Test
+  public void shouldAppendAllEntriesEvenWithFollowerFailures() {
+    assumeTrue(nodes.size() > 1);
+
+    // given
+    final int partitionId = 1;
+    final ZeebeTestNode leader = helper.awaitLeader(partitionId);
+    final ZeebeLogAppender appender = helper.awaitLeaderAppender(partitionId);
+    final List<ZeebeTestNode> followers =
+        nodes.stream().filter(node -> !node.equals(leader)).collect(Collectors.toList());
+    final List<Indexed<ZeebeEntry>> entries = new ArrayList<>();
+
+    // when
+    for (int i = 0; i < followers.size(); i++) {
+      final ZeebeTestNode follower = followers.get(i);
+      final List<ZeebeTestNode> others =
+          nodes.stream().filter(node -> !node.equals(follower)).collect(Collectors.toList());
+      follower.stop().join();
+
+      entries.add(i, appender.appendEntry(getIntAsBytes(i)).join());
+      helper.awaitAllContains(others, partitionId, entries.get(i));
+      follower.start(nodes).join();
+    }
+
+    // then
+    for (final Indexed<ZeebeEntry> entry : entries) {
+      helper.awaitAllContain(partitionId, entry);
+    }
+  }
+
+  private static Function<TemporaryFolder, ZeebeTestNode> provideNode(final int id) {
+    return tmp -> new ZeebeTestNode(id, newFolderUnchecked(tmp, id));
+  }
+
+  private static File newFolderUnchecked(final TemporaryFolder tmp, final int id) {
+    try {
+      return tmp.newFolder(String.valueOf(id));
+    } catch (final IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  private void start() throws ExecutionException, InterruptedException, TimeoutException {
+    Futures.allOf(nodes.stream().map(n -> n.start(nodes))).get(30, TimeUnit.SECONDS);
+  }
+
+  private void stop() throws InterruptedException, ExecutionException, TimeoutException {
+    Futures.allOf(nodes.stream().map(ZeebeTestNode::stop)).get(30, TimeUnit.SECONDS);
+  }
+
+  private byte[] getIntAsBytes(final int value) {
+    return ByteBuffer.allocate(Integer.BYTES).putInt(value).array();
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftPartitionGroup.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftPartitionGroup.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe.partition;
+
+import io.atomix.primitive.partition.ManagedPartitionGroup;
+import io.atomix.primitive.partition.PartitionGroup;
+import io.atomix.protocols.raft.partition.RaftPartitionGroup;
+import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
+import io.atomix.utils.serializer.Namespace;
+import io.atomix.utils.serializer.Namespaces;
+
+public class ZeebeRaftPartitionGroup extends RaftPartitionGroup {
+  public static final ZeebeRaftPartitionGroup.Type TYPE = new ZeebeRaftPartitionGroup.Type();
+
+  public ZeebeRaftPartitionGroup(final RaftPartitionGroupConfig config) {
+    super(config);
+  }
+
+  /**
+   * Returns a new Raft partition group builder.
+   *
+   * @param name the partition group name
+   * @return a new partition group builder
+   */
+  public static Builder builder(final String name) {
+    return new Builder(new ZeebeRaftPartitionGroupConfig().setName(name));
+  }
+
+  /** Raft partition group type. */
+  public static class Type implements PartitionGroup.Type<RaftPartitionGroupConfig> {
+    private static final String NAME = "zeebe-raft";
+
+    @Override
+    public String name() {
+      return NAME;
+    }
+
+    @Override
+    public Namespace namespace() {
+      return Namespace.builder()
+          .nextId(Namespaces.BEGIN_USER_CUSTOM_ID + 100)
+          .register(RaftPartitionGroup.TYPE.namespace())
+          .build();
+    }
+
+    @Override
+    public ManagedPartitionGroup newPartitionGroup(final RaftPartitionGroupConfig config) {
+      return new ZeebeRaftPartitionGroup(config);
+    }
+
+    @Override
+    public RaftPartitionGroupConfig newConfig() {
+      return new ZeebeRaftPartitionGroupConfig();
+    }
+  }
+
+  public static class Builder extends RaftPartitionGroup.Builder {
+    protected Builder(final RaftPartitionGroupConfig config) {
+      super(config);
+    }
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftPartitionGroupConfig.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftPartitionGroupConfig.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe.partition;
+
+import io.atomix.primitive.partition.PartitionGroup.Type;
+import io.atomix.protocols.raft.RaftStateMachineFactory;
+import io.atomix.protocols.raft.partition.RaftPartitionGroupConfig;
+
+public class ZeebeRaftPartitionGroupConfig extends RaftPartitionGroupConfig {
+  @Override
+  public Type getType() {
+    return ZeebeRaftPartitionGroup.TYPE;
+  }
+
+  @Override
+  public RaftStateMachineFactory getStateMachineFactory() {
+    return ZeebeRaftStateMachine::new;
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftStateMachine.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftStateMachine.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe.partition;
+
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.protocols.raft.impl.RaftServiceManager;
+import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.concurrent.ThreadContext;
+import io.atomix.utils.concurrent.ThreadContextFactory;
+import java.time.Duration;
+import java.util.concurrent.CompletableFuture;
+
+public class ZeebeRaftStateMachine extends RaftServiceManager {
+  private static final Duration SNAPSHOT_COMPLETION_DELAY = Duration.ofMillis(0);
+  private static final Duration COMPACT_DELAY = Duration.ofMillis(0);
+
+  private volatile long compactableIndex;
+  private volatile long compactableTerm;
+
+  public ZeebeRaftStateMachine(
+      final RaftContext raft,
+      final ThreadContext stateContext,
+      final ThreadContextFactory threadContextFactory) {
+    super(raft, stateContext, threadContextFactory);
+  }
+
+  @Override
+  public void setCompactablePosition(final long index, final long term) {
+    if (term > compactableTerm) {
+      compactableIndex = index;
+      compactableTerm = term;
+    } else if (term == compactableTerm && index > compactableIndex) {
+      compactableIndex = index;
+    }
+  }
+
+  @Override
+  public long getCompactableIndex() {
+    return compactableIndex;
+  }
+
+  @Override
+  public long getCompactableTerm() {
+    return compactableTerm;
+  }
+
+  @Override
+  public <T> CompletableFuture<T> apply(final Indexed<? extends RaftLogEntry> entry) {
+    if (entry.type() == ZeebeEntry.class) {
+      return CompletableFuture.completedFuture(null);
+    }
+
+    return super.apply(entry);
+  }
+
+  @Override
+  protected Duration getSnapshotCompletionDelay() {
+    return SNAPSHOT_COMPLETION_DELAY;
+  }
+
+  @Override
+  protected Duration getCompactDelay() {
+    return COMPACT_DELAY;
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe.util;
+
+import static org.junit.Assert.assertTrue;
+
+import io.atomix.protocols.raft.RaftServer.Role;
+import io.atomix.protocols.raft.partition.impl.RaftPartitionServer;
+import io.atomix.protocols.raft.storage.log.RaftLogReader;
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeLogAppender;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.storage.journal.JournalReader.Mode;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
+/** Utilities to help write tests; as these are utils, everything is public by default */
+@SuppressWarnings("WeakerAccess")
+public class ZeebeTestHelper {
+  private static final long DEFAULT_TIMEOUT_MS = 10_000;
+  private final Collection<ZeebeTestNode> nodes;
+
+  public ZeebeTestHelper(final Collection<ZeebeTestNode> nodes) {
+    this.nodes = nodes;
+  }
+
+  public ZeebeLogAppender awaitLeaderAppender(final int partitionId) {
+    final RaftPartitionServer server = awaitLeaderServer(partitionId);
+    return await(server::getAppender);
+  }
+
+  public RaftPartitionServer awaitLeaderServer(final int partitionId) {
+    return awaitLeader(partitionId).getPartitionServer(partitionId);
+  }
+
+  public ZeebeTestNode awaitLeader(final int partitionId) {
+    return await(() -> getLeader(partitionId));
+  }
+
+  public Optional<ZeebeTestNode> getLeader(final int partitionId) {
+    return nodes.stream()
+        .filter(n -> n.getPartition(partitionId).getRole() == Role.LEADER)
+        .findFirst();
+  }
+
+  public void awaitAllContain(final int partitionId, final Indexed<ZeebeEntry> indexed) {
+    awaitAllContains(nodes, partitionId, indexed);
+  }
+
+  public void awaitAllContains(
+      final Collection<ZeebeTestNode> nodes,
+      final int partitionId,
+      final Indexed<ZeebeEntry> indexed) {
+    await(() -> nodes.stream().allMatch(node -> containsIndexed(node, partitionId, indexed)));
+  }
+
+  public void awaitContains(
+      final ZeebeTestNode node, final int partitionId, final Indexed<ZeebeEntry> indexed) {
+    await(() -> containsIndexed(node, partitionId, indexed));
+  }
+
+  public boolean containsIndexed(
+      final ZeebeTestNode node, final int partitionId, final Indexed<ZeebeEntry> indexed) {
+    final RaftPartitionServer partition = node.getPartitionServer(partitionId);
+    return containsIndexed(partition, indexed);
+  }
+
+  public boolean containsIndexed(
+      final RaftPartitionServer partition, final Indexed<ZeebeEntry> indexed) {
+    try (final RaftLogReader reader = partition.openReader(indexed.index(), Mode.COMMITS)) {
+
+      if (reader.hasNext() && reader.getNextIndex() == indexed.index()) {
+        final ZeebeEntry entry = reader.next().<ZeebeEntry>cast().entry();
+        return entry.term() == indexed.entry().term()
+            && Arrays.equals(entry.getData(), indexed.entry().getData());
+      }
+    }
+
+    return false;
+  }
+
+  public <T> T await(final Supplier<Optional<T>> supplier) {
+    await(supplier, Optional::isPresent);
+    final Optional<T> result = supplier.get();
+    return result.get();
+  }
+
+  public <T> T await(final Supplier<T> supplier, final Predicate<T> condition) {
+    await(() -> condition.test(supplier.get()));
+    return supplier.get();
+  }
+
+  public void await(final BooleanSupplier predicate) {
+    final long tries = Duration.ofMillis(DEFAULT_TIMEOUT_MS).toNanos() / 100;
+    boolean result = predicate.getAsBoolean();
+    for (long i = 0; i < tries && !result; i++) {
+      LockSupport.parkNanos(100);
+      result = predicate.getAsBoolean();
+    }
+
+    assertTrue(result);
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe.util;
+
+import io.atomix.cluster.AtomixCluster;
+import io.atomix.cluster.ClusterMembershipService;
+import io.atomix.cluster.Member;
+import io.atomix.cluster.MemberId;
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.discovery.NodeDiscoveryProvider;
+import io.atomix.cluster.messaging.ClusterCommunicationService;
+import io.atomix.primitive.impl.ClasspathScanningPrimitiveTypeRegistry;
+import io.atomix.primitive.impl.DefaultPrimitiveTypeRegistry;
+import io.atomix.primitive.partition.ManagedPartitionGroup;
+import io.atomix.primitive.partition.ManagedPartitionService;
+import io.atomix.primitive.partition.impl.DefaultPartitionGroupTypeRegistry;
+import io.atomix.primitive.partition.impl.DefaultPartitionService;
+import io.atomix.protocols.raft.partition.RaftPartition;
+import io.atomix.protocols.raft.partition.RaftPartitionGroup;
+import io.atomix.protocols.raft.partition.impl.RaftPartitionServer;
+import io.atomix.protocols.raft.zeebe.partition.ZeebeRaftPartitionGroup;
+import io.atomix.storage.StorageLevel;
+import java.io.File;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+public class ZeebeTestNode {
+
+  public static final String CLUSTER_ID = "zeebe";
+  private static final String DATA_PARTITION_GROUP_NAME = "data";
+  private static final String SYSTEM_PARTITION_GROUP_NAME = "system";
+  private static final String HOST = "localhost";
+  private static final int BASE_PORT = 10_000;
+  private final Member member;
+  private final Node node;
+  private final File directory;
+
+  private RaftPartitionGroup dataPartitionGroup;
+  private RaftPartitionGroup systemPartitionGroup;
+  private ManagedPartitionService partitionService;
+  private AtomixCluster cluster;
+
+  public ZeebeTestNode(final int id, final File directory) {
+    final String textualId = String.valueOf(id);
+
+    this.directory = directory;
+    this.node = Node.builder().withId(textualId).withHost(HOST).withPort(BASE_PORT + id).build();
+    this.member = Member.member(MemberId.from(textualId), node.address());
+  }
+
+  public MemberId getMemberId() {
+    return member.id();
+  }
+
+  public Member getMember() {
+    return member;
+  }
+
+  public Node getNode() {
+    return node;
+  }
+
+  public AtomixCluster getCluster() {
+    return cluster;
+  }
+
+  RaftPartitionServer getPartitionServer(final int id) {
+    return getPartition(id).getServer();
+  }
+
+  RaftPartition getPartition(final int id) {
+    return (RaftPartition) getDataPartitionGroup().getPartition(String.valueOf(id));
+  }
+
+  private RaftPartitionGroup getDataPartitionGroup() {
+    return (RaftPartitionGroup) partitionService.getPartitionGroup(DATA_PARTITION_GROUP_NAME);
+  }
+
+  public CompletableFuture<Void> start(final Collection<ZeebeTestNode> nodes) {
+    cluster = buildCluster(nodes);
+    systemPartitionGroup =
+        buildPartitionGroup(RaftPartitionGroup.builder(SYSTEM_PARTITION_GROUP_NAME), nodes).build();
+    dataPartitionGroup =
+        buildPartitionGroup(ZeebeRaftPartitionGroup.builder(DATA_PARTITION_GROUP_NAME), nodes)
+            .build();
+    partitionService =
+        buildPartitionService(cluster.getMembershipService(), cluster.getCommunicationService());
+
+    return cluster.start().thenCompose(ignored -> partitionService.start()).thenApply(v -> null);
+  }
+
+  public CompletableFuture<Void> stop() {
+    return partitionService
+        .stop()
+        .thenCompose(ignored -> systemPartitionGroup.close())
+        .thenCompose(ignored -> dataPartitionGroup.close())
+        .thenCompose(ignored -> cluster.stop());
+  }
+
+  private AtomixCluster buildCluster(final Collection<ZeebeTestNode> nodes) {
+    return AtomixCluster.builder()
+        .withAddress(node.address())
+        .withClusterId(CLUSTER_ID)
+        .withMembershipProvider(buildDiscoveryProvider(nodes))
+        .withMemberId(getMemberId())
+        .build();
+  }
+
+  private NodeDiscoveryProvider buildDiscoveryProvider(final Collection<ZeebeTestNode> nodes) {
+    return BootstrapDiscoveryProvider.builder()
+        .withNodes(nodes.stream().map(ZeebeTestNode::getNode).collect(Collectors.toList()))
+        .build();
+  }
+
+  private RaftPartitionGroup.Builder buildPartitionGroup(
+      final RaftPartitionGroup.Builder builder, final Collection<ZeebeTestNode> nodes) {
+    final Set<Member> members =
+        nodes.stream().map(ZeebeTestNode::getMember).collect(Collectors.toSet());
+    members.add(member);
+
+    return builder
+        .withDataDirectory(directory)
+        .withMembers(members.toArray(new Member[0]))
+        .withNumPartitions(1)
+        .withPartitionSize(members.size())
+        .withFlushOnCommit()
+        .withStorageLevel(StorageLevel.DISK)
+        .withSegmentSize(1024L);
+  }
+
+  private ManagedPartitionService buildPartitionService(
+      final ClusterMembershipService clusterMembershipService,
+      final ClusterCommunicationService messagingService) {
+    final ClasspathScanningPrimitiveTypeRegistry registry =
+        new ClasspathScanningPrimitiveTypeRegistry(this.getClass().getClassLoader());
+    final List<ManagedPartitionGroup> partitionGroups =
+        Collections.singletonList(dataPartitionGroup);
+
+    return new DefaultPartitionService(
+        clusterMembershipService,
+        messagingService,
+        new DefaultPrimitiveTypeRegistry(registry.getPrimitiveTypes()),
+        systemPartitionGroup,
+        partitionGroups,
+        new DefaultPartitionGroupTypeRegistry(Collections.singleton(RaftPartitionGroup.TYPE)));
+  }
+}


### PR DESCRIPTION
- decouples RaftServiceManager from RaftServer by introducing RaftStateMachine and RaftStateMachineFactory interfaces, allowing users to supply their own implementations
- exposes some fields for extension and visibility
- adds new methods in RaftPartitionServer that server as entry point to use MultiRaft standalone
- introduces ZeebeLogAppender interface which defines minimum required local append operation
- implements ZeebeLogAppender in LeaderRole for now
- adds tests and testing utilities