### PR TITLE
fix(protocols): run compaction even under highload

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -32,6 +32,7 @@ import io.atomix.protocols.raft.impl.RaftServiceManager;
 import io.atomix.protocols.raft.protocol.RaftServerProtocol;
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.protocols.raft.storage.log.RaftLog;
+import io.atomix.protocols.raft.utils.LoadMonitor;
 import io.atomix.protocols.raft.utils.LoadMonitorFactory;
 import io.atomix.storage.StorageLevel;
 import io.atomix.utils.concurrent.ThreadContextFactory;
@@ -590,7 +591,7 @@ public interface RaftServer {
     protected int threadPoolSize = DEFAULT_THREAD_POOL_SIZE;
     protected ThreadContextFactory threadContextFactory;
     protected RaftStateMachineFactory stateMachineFactory = RaftServiceManager::new;
-    protected LoadMonitorFactory loadMonitorFactory;
+    protected LoadMonitorFactory loadMonitorFactory = LoadMonitor::new;
 
     protected Builder(MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -284,7 +284,8 @@ public class DefaultRaftServer implements RaftServer {
           primitiveTypes,
           threadContextFactory,
           closeOnStop,
-          stateMachineFactory);
+          stateMachineFactory,
+          loadMonitorFactory);
       raft.setElectionTimeout(electionTimeout);
       raft.setHeartbeatInterval(heartbeatInterval);
       raft.setSessionTimeout(sessionTimeout);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -121,21 +121,6 @@ public class RaftContext implements AutoCloseable {
   private volatile long lastApplied;
   private volatile long lastAppliedTerm;
 
-  public RaftContext(
-      String name,
-      MemberId localMemberId,
-      ClusterMembershipService membershipService,
-      RaftServerProtocol protocol,
-      RaftStorage storage,
-      PrimitiveTypeRegistry primitiveTypes,
-      ThreadContextFactory threadContextFactory,
-      boolean closeOnStop,
-      RaftStateMachineFactory stateMachineFactory) {
-    this(name, localMemberId, membershipService, protocol, storage, primitiveTypes,
-        threadContextFactory, closeOnStop, stateMachineFactory, null);
-
-  }
-
   @SuppressWarnings("unchecked")
   public RaftContext(
       String name,
@@ -170,10 +155,8 @@ public class RaftContext implements AutoCloseable {
     this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
     this.closeOnStop = closeOnStop;
 
-    this.loadMonitor =
-        loadMonitorFactory == null ? new LoadMonitor(LOAD_WINDOW_SIZE, HIGH_LOAD_THRESHOLD,
-            loadContext) : loadMonitorFactory
-            .createLoadMonitor(LOAD_WINDOW_SIZE, HIGH_LOAD_THRESHOLD, loadContext);
+    checkNotNull(loadMonitorFactory, "loadMonitorFactory must be not null");
+    this.loadMonitor = loadMonitorFactory.createLoadMonitor(LOAD_WINDOW_SIZE, HIGH_LOAD_THRESHOLD, loadContext);
 
     // Open the metadata store.
     this.meta = storage.openMetaStore();
@@ -191,6 +174,7 @@ public class RaftContext implements AutoCloseable {
     this.snapshotStore = storage.openSnapshotStore();
 
     // Create a new internal server state machine.
+    checkNotNull(stateMachineFactory, "stateMachineFactory must be not null");
     this.stateMachine = stateMachineFactory.createStateMachine(this, stateContext, threadContextFactory);
 
     this.cluster = new RaftClusterContext(localMemberId, this);

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.protocols.raft.impl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import com.google.common.collect.Maps;
 import com.google.common.primitives.Longs;
 import io.atomix.cluster.MemberId;
@@ -43,7 +45,6 @@ import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.protocols.raft.storage.snapshot.Snapshot;
 import io.atomix.protocols.raft.storage.snapshot.SnapshotReader;
 import io.atomix.protocols.raft.storage.snapshot.SnapshotWriter;
-import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.AtomixIOException;
 import io.atomix.utils.concurrent.ComposableFuture;
@@ -55,8 +56,6 @@ import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import io.atomix.utils.serializer.Serializer;
 import io.atomix.utils.time.WallClockTimestamp;
-import org.slf4j.Logger;
-
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -65,8 +64,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
-
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.slf4j.Logger;
 
 /**
  * Internal server state machine.
@@ -131,13 +129,10 @@ public class RaftServiceManager implements RaftStateMachine {
    * Returns a boolean indicating whether the node is running out of memory.
    */
   private boolean isRunningOutOfMemory() {
-    StorageLevel level = raft.getStorage().storageLevel();
-    if (level == StorageLevel.MEMORY || level == StorageLevel.MAPPED) {
-      long freeMemory = raft.getStorage().statistics().getFreeMemory();
-      long totalMemory = raft.getStorage().statistics().getTotalMemory();
-      if (freeMemory > 0 && totalMemory > 0) {
-        return freeMemory / (double) totalMemory < raft.getStorage().freeMemoryBuffer();
-      }
+    final long freeMemory = raft.getStorage().statistics().getFreeMemory();
+    final long totalMemory = raft.getStorage().statistics().getTotalMemory();
+    if (freeMemory > 0 && totalMemory > 0) {
+      return freeMemory / (double) totalMemory < raft.getStorage().freeMemoryBuffer();
     }
     return false;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -92,7 +92,8 @@ public class RaftStorage {
       double freeDiskBuffer,
       double freeMemoryBuffer,
       boolean flushOnCommit,
-      boolean retainStaleSnapshots) {
+      boolean retainStaleSnapshots,
+      StorageStatistics storageStatistics) {
     this.prefix = prefix;
     this.storageLevel = storageLevel;
     this.directory = directory;
@@ -105,7 +106,7 @@ public class RaftStorage {
     this.freeMemoryBuffer = freeMemoryBuffer;
     this.flushOnCommit = flushOnCommit;
     this.retainStaleSnapshots = retainStaleSnapshots;
-    this.statistics = new StorageStatistics(directory);
+    this.statistics = storageStatistics == null ? new StorageStatistics(directory) : storageStatistics;
     directory.mkdirs();
   }
 
@@ -409,6 +410,7 @@ public class RaftStorage {
     private double freeMemoryBuffer = DEFAULT_FREE_MEMORY_BUFFER;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     private boolean retainStaleSnapshots = DEFAULT_RETAIN_STALE_SNAPSHOTS;
+    private StorageStatistics storageStatistics;
 
     private Builder() {
     }
@@ -648,6 +650,18 @@ public class RaftStorage {
     }
 
     /**
+     * Sets the storage statistics, which are evaluated for deciding to force compaction or not.
+     * Depending on the free memory and/or free disk space ratio the compaction is forced.
+     *
+     * @param storageStatistics the statistics which are evaluated
+     * @return The storage builder.
+     */
+    public Builder withStorageStatistics(StorageStatistics storageStatistics) {
+      this.storageStatistics = storageStatistics;
+      return this;
+    }
+
+    /**
      * Builds the {@link RaftStorage} object.
      *
      * @return The built storage configuration.
@@ -666,7 +680,8 @@ public class RaftStorage {
           freeDiskBuffer,
           freeMemoryBuffer,
           flushOnCommit,
-          retainStaleSnapshots);
+          retainStaleSnapshots,
+          storageStatistics);
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -32,6 +32,7 @@ import io.atomix.utils.serializer.Serializer;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Optional;
 import java.util.function.Predicate;
 
 import static com.google.common.base.MoreObjects.toStringHelper;
@@ -106,7 +107,7 @@ public class RaftStorage {
     this.freeMemoryBuffer = freeMemoryBuffer;
     this.flushOnCommit = flushOnCommit;
     this.retainStaleSnapshots = retainStaleSnapshots;
-    this.statistics = storageStatistics == null ? new StorageStatistics(directory) : storageStatistics;
+    this.statistics = storageStatistics;
     directory.mkdirs();
   }
 
@@ -681,7 +682,7 @@ public class RaftStorage {
           freeMemoryBuffer,
           flushOnCommit,
           retainStaleSnapshots,
-          storageStatistics);
+          Optional.ofNullable(storageStatistics).orElse(new StorageStatistics(directory)));
     }
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/utils/LoadMonitorFactory.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/utils/LoadMonitorFactory.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.utils;
+
+import io.atomix.utils.concurrent.ThreadContext;
+
+@FunctionalInterface
+public interface LoadMonitorFactory {
+  LoadMonitor createLoadMonitor(int windowSize, int highLoadThreshold, ThreadContext threadContext);
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/impl/RaftServiceManagerTest.java
@@ -48,6 +48,7 @@ import io.atomix.protocols.raft.storage.log.entry.MetadataEntry;
 import io.atomix.protocols.raft.storage.log.entry.OpenSessionEntry;
 import io.atomix.protocols.raft.storage.log.entry.QueryEntry;
 import io.atomix.protocols.raft.storage.snapshot.Snapshot;
+import io.atomix.protocols.raft.utils.LoadMonitor;
 import io.atomix.utils.concurrent.ThreadModel;
 import io.atomix.utils.serializer.Namespace;
 import org.junit.After;
@@ -252,7 +253,8 @@ public class RaftServiceManagerTest {
         registry,
         ThreadModel.SHARED_THREAD_POOL.factory("raft-server-test-%d", 1, LoggerFactory.getLogger(RaftServer.class)),
         true,
-        RaftServiceManager::new);
+        RaftServiceManager::new,
+        LoadMonitor::new);
 
     snapshotTaken = new AtomicBoolean();
     snapshotInstalled = new AtomicBoolean();

--- a/storage/src/main/java/io/atomix/storage/statistics/StorageStatistics.java
+++ b/storage/src/main/java/io/atomix/storage/statistics/StorageStatistics.java
@@ -15,27 +15,17 @@
  */
 package io.atomix.storage.statistics;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.File;
-import java.lang.management.ManagementFactory;
-
-import javax.management.MBeanServer;
-import javax.management.ObjectName;
 
 /**
  * Atomix storage statistics.
  */
 public class StorageStatistics {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StorageStatistics.class);
 
   private final File file;
-  private final MBeanServer mBeanServer;
 
   public StorageStatistics(File file) {
     this.file = file;
-    this.mBeanServer = ManagementFactory.getPlatformMBeanServer();
   }
 
   /**
@@ -71,14 +61,7 @@ public class StorageStatistics {
    * @return the amount of free memory remaining if successful, -1 return indicates failure.
    */
   public long getFreeMemory() {
-    try {
-      return (long) mBeanServer.getAttribute(new ObjectName("java.lang", "type", "OperatingSystem"), "FreePhysicalMemorySize");
-    } catch (Exception e) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("An exception occurred during memory check", e);
-      }
-    }
-    return -1;
+    return Runtime.getRuntime().freeMemory();
   }
 
   /**
@@ -87,13 +70,6 @@ public class StorageStatistics {
    * @return the total amount of memory if successful, -1 return indicates failure.
    */
   public long getTotalMemory() {
-    try {
-      return (long) mBeanServer.getAttribute(new ObjectName("java.lang", "type", "OperatingSystem"), "TotalPhysicalMemorySize");
-    } catch (Exception e) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("An exception occurred during memory check", e);
-      }
-    }
-    return -1;
+    return Runtime.getRuntime().totalMemory();
   }
 }


### PR DESCRIPTION
 * compaction was skipped under highload even if we are going out of memory - because DISK storage level was not considered and wrong values for memory are used

See related issue https://github.com/zeebe-io/zeebe/issues/3090