### PR TITLE
chore(raft): add prometheus metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
     <resteasy.version>3.1.4.Final</resteasy.version>
     <rest-assured.version>3.0.7</rest-assured.version>
     <argparse4j.version>0.7.0</argparse4j.version>
+    <prometheus.client.version>0.7.0</prometheus.client.version>
 
     <!-- Maven plugins -->
     <maven.source.plugin.version>2.2.1</maven.source.plugin.version>

--- a/protocols/raft/pom.xml
+++ b/protocols/raft/pom.xml
@@ -32,6 +32,11 @@
       <artifactId>atomix-primitive</artifactId>
       <version>${project.version}</version>
     </dependency>
+    <dependency>
+      <groupId>io.prometheus</groupId>
+      <artifactId>simpleclient</artifactId>
+      <version>${prometheus.client.version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/LeaderMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/LeaderMetrics.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.metrics;
+
+import io.prometheus.client.Histogram;
+
+public class LeaderMetrics extends RaftMetrics {
+
+  private static final Histogram APPEND_LATENCY =
+      Histogram.build()
+          .namespace("atomix")
+          .name("append_entries_latency_ms")
+          .help("Latency to append an entry to a follower")
+          .labelNames("follower", "partitionName")
+          .register();
+
+  public LeaderMetrics(String partitionName) {
+    super(partitionName);
+  }
+
+  public void appendComplete(long latencyms, String memberId) {
+    APPEND_LATENCY.labels(memberId, partition).observe(latencyms);
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.metrics;
+
+import org.slf4j.LoggerFactory;
+
+public class RaftMetrics {
+
+  protected final String partition;
+
+  public RaftMetrics(String partitionName) {
+    int partitionId;
+    try {
+      final String[] parts = partitionName.split("-");
+      partitionId = Integer.valueOf(parts[parts.length - 1]);
+    } catch (Exception e) {
+      LoggerFactory.getLogger(RaftMetrics.class)
+          .debug("Cannot extract partition id from name {}, defaulting to 0", partitionName);
+      partitionId = 0;
+    }
+    this.partition = String.valueOf(partitionId);
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRequestMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRequestMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.metrics;
+
+import io.prometheus.client.Counter;
+
+public class RaftRequestMetrics extends RaftMetrics {
+
+  private static final Counter RAFT_MESSAGES_RECEIVED =
+      Counter.build()
+          .namespace("atomix")
+          .name("raft_messages_received")
+          .help("Number of raft requests received")
+          .labelNames("type", "partitionName")
+          .register();
+
+  private static final Counter RAFT_MESSAGES_SEND =
+      Counter.build()
+          .namespace("atomix")
+          .name("raft_messages_send")
+          .help("Number of raft requests send")
+          .labelNames("to", "type", "partitionName")
+          .register();
+
+  public RaftRequestMetrics(String partitionName) {
+    super(partitionName);
+  }
+
+  public void receivedMessage(String type) {
+    RAFT_MESSAGES_RECEIVED.labels(type, partition).inc();
+  }
+
+  public void sendMessage(String memberId, String type) {
+    RAFT_MESSAGES_SEND.labels(memberId, type, partition).inc();
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftServiceMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftServiceMetrics.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.metrics;
+
+import io.prometheus.client.Histogram;
+
+public class RaftServiceMetrics extends RaftMetrics {
+
+  private static final Histogram SNAPSHOTING_TIME =
+      Histogram.build()
+          .namespace("atomix")
+          .name("snapshot_time_ms")
+          .help("Time spend to take a snapshot")
+          .labelNames("partitionName")
+          .register();
+
+  private static final Histogram COMPACTION_TIME =
+      Histogram.build()
+          .namespace("atomix")
+          .name("compaction_time_ms")
+          .help("Time spend to compact")
+          .labelNames("partitionName")
+          .register();
+
+  public RaftServiceMetrics(String partitionName) {
+    super(partitionName);
+  }
+
+  public void snapshotTime(long latencyms) {
+    SNAPSHOTING_TIME.labels(partition).observe(latencyms);
+  }
+
+  public void compactionTime(long latencyms) {
+    COMPACTION_TIME.labels(partition).observe(latencyms);
+  }
+}


### PR DESCRIPTION
Adds following Prometheus metrics 
 * append entries latency
 * number of raft requests send and received
 * snapshoting and compaction time 