### PR TITLE
chore(raft): add raft metrics

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.metrics;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+
+public class RaftRoleMetrics extends RaftMetrics {
+
+  private static final Gauge ROLE =
+      Gauge.build()
+          .namespace("atomix")
+          .name("role")
+          .help("Shows current role")
+          .labelNames("partition")
+          .register();
+
+  private static final Counter HEARTBEAT_MISS =
+      Counter.build()
+          .namespace("atomix")
+          .name("heartbeat_miss_count")
+          .help("Count of missing heartbeats")
+          .labelNames("partition")
+          .register();
+
+  private static final Histogram HEARTBEAT_TIME =
+      Histogram.build()
+          .namespace("atomix")
+          .name("heartbeat_time_in_s")
+          .help("Time between heartbeats")
+          .labelNames("partition")
+          .register();
+
+  public RaftRoleMetrics(String partitionName) {
+    super(partitionName);
+  }
+
+  public void becomingFollower() {
+    ROLE.labels(partition).set(1);
+  }
+
+  public void becomingCandidate() {
+    ROLE.labels(partition).set(2);
+  }
+
+  public void becomingLeader() {
+    ROLE.labels(partition).set(3);
+  }
+
+  public void countHeartbeatMiss() {
+    HEARTBEAT_MISS.labels(partition).inc();
+  }
+
+  public void observeHeartbeatInterval(long milliseconds) {
+    HEARTBEAT_TIME.labels(partition).observe(milliseconds / 1000f);
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -35,7 +35,6 @@ import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.protocols.raft.utils.Quorum;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.concurrent.Scheduled;
-
 import java.time.Duration;
 import java.util.Random;
 import java.util.Set;
@@ -50,6 +49,7 @@ public final class FollowerRole extends ActiveRole {
   private final ClusterMembershipEventListener clusterListener = this::handleClusterEvent;
   private final Random random = new Random();
   private Scheduled heartbeatTimer;
+  private long lastHeartbeat;
 
   public FollowerRole(RaftContext context) {
     super(context);
@@ -103,9 +103,14 @@ public final class FollowerRole extends ActiveRole {
     Duration delay = raft.getElectionTimeout().plus(Duration.ofMillis(random.nextInt((int) raft.getElectionTimeout().toMillis())));
     heartbeatTimer = raft.getThreadContext().schedule(delay, () -> {
       heartbeatTimer = null;
-      if (isRunning() && (raft.getFirstCommitIndex() == 0 || raft.getState() == RaftContext.State.READY)) {
+      if (isRunning() && (raft.getFirstCommitIndex() == 0
+          || raft.getState() == RaftContext.State.READY)) {
+        final long missTime = System.currentTimeMillis() - lastHeartbeat;
+        log.info("No heartbeat from {} in the last {} (calculated from last {} ms)",
+            raft.getLeader(), delay, missTime);
+        raft.getRaftRoleMetrics().countHeartbeatMiss();
+
         raft.setLeader(null);
-        log.debug("Heartbeat timed out in {}", delay);
         sendPollRequests();
       }
     });
@@ -210,6 +215,11 @@ public final class FollowerRole extends ActiveRole {
 
   @Override
   public CompletableFuture<AppendResponse> onAppend(AppendRequest request) {
+    final long currentHeartbeatTime = System.currentTimeMillis();
+    if (lastHeartbeat > 0) {
+      raft.getRaftRoleMetrics().observeHeartbeatInterval(currentHeartbeatTime - lastHeartbeat);
+    }
+    lastHeartbeat = currentHeartbeatTime;
     CompletableFuture<AppendResponse> future = super.onAppend(request);
 
     // Reset the heartbeat timeout.


### PR DESCRIPTION
 * adds gauge for the raft role which indicates the current role
 * adds historgram for the time between heartbeats
 * adds count to count missed heartbeats


In action looks like this:

![screenshot](https://user-images.githubusercontent.com/2758593/67562193-89884700-f71e-11e9-9662-773b0c5af5fc.png)
