### PR TITLE
chore(dist): do not build docker image on mvn build

### DIFF
--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -83,38 +83,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>com.spotify</groupId>
-        <artifactId>dockerfile-maven-plugin</artifactId>
-        <version>${maven.dockerfile.plugin.version}</version>
-        <inherited>false</inherited>
-        <executions>
-          <execution>
-            <id>default</id>
-            <goals>
-              <goal>build</goal>
-              <goal>push</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <repository>atomix/atomix</repository>
-          <tag>${dockerfile.version}</tag>
-        </configuration>
-        <!-- See https://github.com/spotify/dockerfile-maven/issues/200 -->
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.plexus</groupId>
-            <artifactId>plexus-archiver</artifactId>
-            <version>3.6.0</version>
-          </dependency>
-          <dependency>
-            <groupId>javax.activation</groupId>
-            <artifactId>javax.activation-api</artifactId>
-            <version>1.2.0</version>
-          </dependency>
-        </dependencies>
-      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
I do not want to build the docker image everytime I run `mvn clean install`. Furthermore I dont think we need it.