### PR TITLE
chore(storage): adds support for faster entry lookup

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeEntry.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeEntry.java
@@ -15,24 +15,78 @@
  */
 package io.atomix.protocols.raft.zeebe;
 
+import static com.google.common.base.MoreObjects.toStringHelper;
+
 import io.atomix.protocols.raft.storage.log.entry.TimestampedEntry;
+import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
- * Stores a free-form entry.
- * <p>
- * Each entry is written with the leader's {@link #timestamp() timestamp} at the time the entry was logged
- * This gives state machines an approximation of time with which to react to the application of entries to the
- * state machine.
+ * Stores an entry that contains serialized records, ordered by their position; the lowestPosition
+ * and highestPosition metadata allow for fast binary search over a collection of entries to quickly
+ * find a particular record.
+ *
+ * <p>Each entry is written with the leader's {@link #timestamp() timestamp} at the time the entry
+ * was logged This gives state machines an approximation of time with which to react to the
+ * application of entries to the state machine.
  */
 public class ZeebeEntry extends TimestampedEntry {
-  private final byte[] data;
+  private final long lowestPosition;
+  private final long highestPosition;
+  private final ByteBuffer data;
 
-  public ZeebeEntry(long term, long timestamp, byte[] data) {
+  public ZeebeEntry(
+      long term, long timestamp, long lowestPosition, long highestPosition, ByteBuffer data) {
     super(term, timestamp);
+    this.lowestPosition = lowestPosition;
+    this.highestPosition = highestPosition;
     this.data = data;
   }
 
-  public byte[] getData() {
+  public long lowestPosition() {
+    return lowestPosition;
+  }
+
+  public long highestPosition() {
+    return highestPosition;
+  }
+
+  public ByteBuffer data() {
     return data;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (!super.equals(other)) {
+      return false;
+    }
+
+    if (!(other instanceof ZeebeEntry)) {
+      return false;
+    }
+
+    final ZeebeEntry that = (ZeebeEntry) other;
+    return lowestPosition() == that.lowestPosition()
+        && highestPosition() == that.highestPosition()
+        && data().equals(that.data());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), lowestPosition(), highestPosition(), data());
+  }
+
+  @Override
+  public String toString() {
+    return toStringHelper(this)
+        .add("term", term())
+        .add("timestamp", timestamp())
+        .add("lowestPosition", lowestPosition())
+        .add("highestPosition", highestPosition())
+        .toString();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
@@ -16,7 +16,7 @@
 package io.atomix.protocols.raft.zeebe;
 
 import io.atomix.storage.journal.Indexed;
-
+import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
 
 @FunctionalInterface
@@ -24,8 +24,11 @@ public interface ZeebeLogAppender {
   /**
    * Appends an entry to the local Raft log and schedules replication to each follower.
    *
+   * @param lowestPosition lowest record position in the data buffer
+   * @param highestPosition highest record position in the data buffer
    * @param data data to store in the entry
    * @return a future which is completed with the indexed entry without waiting for replication
    */
-  CompletableFuture<Indexed<ZeebeEntry>> appendEntry(byte[] data);
+  CompletableFuture<Indexed<ZeebeEntry>> appendEntry(
+      long lowestPosition, long highestPosition, ByteBuffer data);
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
@@ -25,7 +25,6 @@ import io.atomix.protocols.raft.zeebe.ZeebeLogAppender;
 import io.atomix.storage.journal.Indexed;
 import io.atomix.storage.journal.JournalReader.Mode;
 import java.time.Duration;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.concurrent.locks.LockSupport;
@@ -96,9 +95,10 @@ public class ZeebeTestHelper {
     return false;
   }
 
-  public boolean isEntryEqualTo(final Indexed<ZeebeEntry> indexed, final Indexed<ZeebeEntry> other) {
+  public boolean isEntryEqualTo(
+      final Indexed<ZeebeEntry> indexed, final Indexed<ZeebeEntry> other) {
     return indexed.entry().term() == other.entry().term()
-        && Arrays.equals(indexed.entry().getData(), other.entry().getData());
+        && indexed.entry().data().equals(other.entry().data());
   }
 
   public <T> T await(final Supplier<Optional<T>> supplier) {

--- a/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalReader.java
@@ -33,6 +33,11 @@ public class DelegatingJournalReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public long getLastIndex() {
+    return delegate.getLastIndex();
+  }
+
+  @Override
   public long getCurrentIndex() {
     return delegate.getCurrentIndex();
   }

--- a/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -39,7 +39,7 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
   private final JournalIndex index;
   private final Namespace namespace;
   private final ByteBuffer memory;
-  private final long firstIndex;
+  private final JournalSegment<E> segment;
   private Indexed<E> currentEntry;
   private Indexed<E> nextEntry;
 
@@ -54,13 +54,18 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
     this.index = index;
     this.namespace = namespace;
     this.memory = ByteBuffer.allocate((maxEntrySize + Integer.BYTES + Integer.BYTES) * 2);
-    this.firstIndex = segment.index();
+    this.segment = segment;
     reset();
   }
 
   @Override
   public long getFirstIndex() {
-    return firstIndex;
+    return segment.index();
+  }
+
+  @Override
+  public long getLastIndex() {
+    return segment.lastIndex();
   }
 
   @Override
@@ -75,7 +80,7 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
 
   @Override
   public long getNextIndex() {
-    return currentEntry != null ? currentEntry.index() + 1 : firstIndex;
+    return currentEntry != null ? currentEntry.index() + 1 : getFirstIndex();
   }
 
   @Override

--- a/storage/src/main/java/io/atomix/storage/journal/JournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalReader.java
@@ -48,6 +48,14 @@ public interface JournalReader<E> extends Iterator<Indexed<E>>, AutoCloseable {
   long getFirstIndex();
 
   /**
+   * Returns the last index in the journal; if the reader is mode aware, should respect the given
+   * mode (e.g. return commit index if commits only).
+   *
+   * @return the last index in the journal
+   */
+  long getLastIndex();
+
+  /**
    * Returns the current reader index.
    *
    * @return The current reader index.

--- a/storage/src/main/java/io/atomix/storage/journal/MappableJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/MappableJournalSegmentReader.java
@@ -80,6 +80,11 @@ class MappableJournalSegmentReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public long getLastIndex() {
+    return reader.getLastIndex();
+  }
+
+  @Override
   public long getCurrentIndex() {
     return reader.getCurrentIndex();
   }

--- a/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
@@ -34,7 +34,7 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
   private final int maxEntrySize;
   private final JournalIndex index;
   private final Namespace namespace;
-  private final long firstIndex;
+  private final JournalSegment<E> segment;
   private Indexed<E> currentEntry;
   private Indexed<E> nextEntry;
 
@@ -48,13 +48,18 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
     this.maxEntrySize = maxEntrySize;
     this.index = index;
     this.namespace = namespace;
-    this.firstIndex = segment.index();
+    this.segment = segment;
     reset();
   }
 
   @Override
   public long getFirstIndex() {
-    return firstIndex;
+    return segment.index();
+  }
+
+  @Override
+  public long getLastIndex() {
+    return segment.lastIndex();
   }
 
   @Override
@@ -69,7 +74,7 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
 
   @Override
   public long getNextIndex() {
-    return currentEntry != null ? currentEntry.index() + 1 : firstIndex;
+    return currentEntry != null ? currentEntry.index() + 1 : getFirstIndex();
   }
 
   @Override

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalReader.java
@@ -54,6 +54,11 @@ public class SegmentedJournalReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public long getLastIndex() {
+    return mode == Mode.COMMITS ? journal.getCommitIndex() : journal.getLastSegment().lastIndex();
+  }
+
+  @Override
   public long getCurrentIndex() {
     long currentIndex = currentReader.getCurrentIndex();
     if (currentIndex != 0) {

--- a/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
@@ -24,12 +24,14 @@ import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import io.atomix.utils.Version;
 import io.atomix.utils.serializer.serializers.ArraysAsListSerializer;
+import io.atomix.utils.serializer.serializers.ByteBufferSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableListSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableMapSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableSetSerializer;
 import io.atomix.utils.time.LogicalTimestamp;
 import io.atomix.utils.time.WallClockTimestamp;
 
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -105,6 +107,10 @@ public final class Namespaces {
       .register(LogicalTimestamp.class)
       .register(WallClockTimestamp.class)
       .register(Version.class)
+      .register(new ByteBufferSerializer(),
+          ByteBuffer.class,
+          ByteBuffer.allocate(1).getClass(),
+          ByteBuffer.allocateDirect(1).getClass())
       .build("BASIC");
 
   /**

--- a/utils/src/main/java/io/atomix/utils/serializer/serializers/ByteBufferSerializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/serializers/ByteBufferSerializer.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+public class ByteBufferSerializer extends Serializer<ByteBuffer> {
+
+  @Override
+  public void write(final Kryo kryo, final Output output, final ByteBuffer object) {
+    output.writeBoolean(object.isDirect());
+    output.writeBoolean(ByteOrder.LITTLE_ENDIAN.equals(object.order()));
+    output.writeInt(object.remaining());
+    for (int i = object.position(); i < object.capacity(); i++) {
+      output.writeByte(object.get(i));
+    }
+  }
+
+  @Override
+  public ByteBuffer read(final Kryo kryo, final Input input, final Class<ByteBuffer> type) {
+    final boolean isDirect = input.readBoolean();
+    final boolean isLittleEndian = input.readBoolean();
+    final int capacity = input.readInt();
+    final ByteBuffer buffer;
+
+    if (isDirect) {
+      buffer = ByteBuffer.allocateDirect(capacity);
+    } else {
+      buffer = ByteBuffer.allocate(capacity);
+    }
+
+    if (isLittleEndian) {
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+    } else {
+      buffer.order(ByteOrder.BIG_ENDIAN);
+    }
+
+    for (int i = 0; i < capacity; i++) {
+      buffer.put(i, input.readByte());
+    }
+
+    return buffer;
+  }
+}

--- a/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.ByteBufferInput;
+import com.esotericsoftware.kryo.io.ByteBufferOutput;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/** Sets up a Kryo instance where we write/read from a shared buffer. */
+public class ByteBufferSerializerTest {
+  private static final int CAPACITY = 1024;
+  private static final Kryo KRYO = new Kryo();
+
+  private Output output;
+  private Input input;
+
+  @BeforeClass
+  public static void register() {
+    KRYO.register(ByteBuffer.class, new ByteBufferSerializer());
+    KRYO.addDefaultSerializer(ByteBuffer.class, new ByteBufferSerializer());
+  }
+
+  @Before
+  public void setUp() {
+    final ByteBuffer buffer = ByteBuffer.allocate(CAPACITY);
+
+    output = new ByteBufferOutput(buffer);
+    input = new ByteBufferInput(buffer);
+  }
+
+  @After
+  public void tearDown() {
+    output.close();
+    input.close();
+  }
+
+  @Test
+  public void shouldSerializeRemainingOnly() {
+    // given
+    final int value = 1;
+    final int capacity = Long.BYTES;
+    final ByteBuffer original = ByteBuffer.allocate(capacity * 2).putLong(value * 2).putLong(value);
+
+    // when
+    original.position(capacity);
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(capacity, deserialized.remaining());
+    assertEquals(capacity, deserialized.capacity());
+    assertEquals(value, deserialized.getLong(0));
+  }
+
+  @Test
+  public void shouldSerializeDirectBuffer() {
+    // given
+    final int value = 1;
+    final int capacity = Long.BYTES;
+    final ByteBuffer original = ByteBuffer.allocateDirect(capacity).putLong(0, value);
+
+    // when
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(capacity, deserialized.remaining());
+    assertEquals(capacity, deserialized.capacity());
+    assertTrue(deserialized.isDirect());
+    assertEquals(value, deserialized.getLong(0));
+  }
+
+  @Test
+  public void shouldSerializeHeapBuffer() {
+    // given
+    final int value = 1;
+    final int capacity = Long.BYTES;
+    final ByteBuffer original = ByteBuffer.allocate(capacity).putLong(0, value);
+
+    // when
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(capacity, deserialized.remaining());
+    assertEquals(capacity, deserialized.capacity());
+    assertFalse(deserialized.isDirect());
+    assertEquals(value, deserialized.getLong(0));
+  }
+
+  @Test
+  public void shouldSerializeLittleEndianBuffer() {
+    // given
+    final int value = 1;
+    final int capacity = Long.BYTES;
+    final ByteBuffer original =
+        ByteBuffer.allocate(capacity).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+
+    // when
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(ByteOrder.LITTLE_ENDIAN, deserialized.order());
+    assertEquals(value, deserialized.getLong(0));
+  }
+
+  @Test
+  public void shouldSerializeBigEndianBuffer() {
+    // given
+    final int value = 1;
+    final int capacity = Long.BYTES;
+    final ByteBuffer original =
+        ByteBuffer.allocate(capacity).order(ByteOrder.BIG_ENDIAN).putLong(0, value);
+
+    // when
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
+    assertEquals(value, deserialized.getLong(0));
+  }
+}


### PR DESCRIPTION
## Description

- exposes last index of journal through `JournalReader` while respecting read mode
- adds lowest/highest position metadata to `ZeebeEntry` to enable binary search over entries
- migrates data from `byte[]` to `ByteBuffer` for future proofing and unnecessary copying
- adds support for `ByteBuffer` serialization in Kryo*

* Note: while we might consider switching away from Kryo in the Raft/Journal module eventually, for now I think it's worth adding support for `ByteBuffer` and first slowly migrate away from `byte[]`.

## Related issues

closes #46  