### PR TITLE
chore(raft): notify commit listeners when applying entry

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftCommitListener.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftCommitListener.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft;
+
+import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.storage.journal.Indexed;
+
+@FunctionalInterface
+public interface RaftCommitListener {
+  <T extends RaftLogEntry> void onCommit(Indexed<T> entry);
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -20,6 +20,7 @@ import io.atomix.cluster.MemberId;
 import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.Partition;
+import io.atomix.protocols.raft.RaftCommitListener;
 import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.RaftPartition;
@@ -36,6 +37,7 @@ import io.atomix.utils.serializer.Serializer;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import org.slf4j.Logger;
 
 import java.io.IOException;
@@ -65,6 +67,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private final PrimitiveTypeRegistry primitiveTypes;
   private final ThreadContextFactory threadContextFactory;
   private final Set<Consumer<Role>> deferredRoleChangeListeners = new CopyOnWriteArraySet<>();
+  private final Set<LongConsumer> commitListeners = new CopyOnWriteArraySet<>();
   private RaftServer server;
 
   public RaftPartitionServer(
@@ -171,6 +174,20 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   public void removeRoleChangeListener(Consumer<Role> listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);
+  }
+
+  /**
+   * @see io.atomix.protocols.raft.impl.RaftContext#addCommitListener(RaftCommitListener)
+   */
+  public void addCommitListener(RaftCommitListener commitListener) {
+    server.getContext().addCommitListener(commitListener);
+  }
+
+  /**
+   * @see io.atomix.protocols.raft.impl.RaftContext#removeCommitListener(RaftCommitListener)
+   */
+  public void removeCommitListener(RaftCommitListener commitListener) {
+    server.getContext().removeCommitListener(commitListener);
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderAppender.java
@@ -135,16 +135,10 @@ final class LeaderAppender extends AbstractAppender {
       return CompletableFuture.completedFuture(index);
     }
 
-    // If there are no other stateful servers in the cluster, immediately commit the index.
-    if (raft.getCluster().getActiveMemberStates().isEmpty() && raft.getCluster().getPassiveMemberStates().isEmpty()) {
-      long previousCommitIndex = raft.getCommitIndex();
-      raft.setCommitIndex(index);
-      completeCommits(previousCommitIndex, index);
-      return CompletableFuture.completedFuture(index);
-    }
+    // If there are no other stateful servers in the cluster, immediately commit the index OR
     // If there are no other active members in the cluster, update the commit index and complete the commit.
     // The updated commit index will be sent to passive/reserve members on heartbeats.
-    else if (raft.getCluster().getActiveMemberStates().isEmpty()) {
+    if (raft.getCluster().getActiveMemberStates().isEmpty()) {
       long previousCommitIndex = raft.getCommitIndex();
       raft.setCommitIndex(index);
       completeCommits(previousCommitIndex, index);

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftStateMachine.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/partition/ZeebeRaftStateMachine.java
@@ -17,13 +17,9 @@ package io.atomix.protocols.raft.zeebe.partition;
 
 import io.atomix.protocols.raft.impl.RaftContext;
 import io.atomix.protocols.raft.impl.RaftServiceManager;
-import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
-import io.atomix.protocols.raft.zeebe.ZeebeEntry;
-import io.atomix.storage.journal.Indexed;
 import io.atomix.utils.concurrent.ThreadContext;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import java.time.Duration;
-import java.util.concurrent.CompletableFuture;
 
 public class ZeebeRaftStateMachine extends RaftServiceManager {
   private static final Duration SNAPSHOT_COMPLETION_DELAY = Duration.ofMillis(0);
@@ -57,15 +53,6 @@ public class ZeebeRaftStateMachine extends RaftServiceManager {
   @Override
   public long getCompactableTerm() {
     return compactableTerm;
-  }
-
-  @Override
-  public <T> CompletableFuture<T> apply(final Indexed<? extends RaftLogEntry> entry) {
-    if (entry.type() == ZeebeEntry.class) {
-      return CompletableFuture.completedFuture(null);
-    }
-
-    return super.apply(entry);
   }
 
   @Override

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestHelper.java
@@ -89,13 +89,16 @@ public class ZeebeTestHelper {
     try (final RaftLogReader reader = partition.openReader(indexed.index(), Mode.COMMITS)) {
 
       if (reader.hasNext() && reader.getNextIndex() == indexed.index()) {
-        final ZeebeEntry entry = reader.next().<ZeebeEntry>cast().entry();
-        return entry.term() == indexed.entry().term()
-            && Arrays.equals(entry.getData(), indexed.entry().getData());
+        return isEntryEqualTo(reader.next().cast(), indexed);
       }
     }
 
     return false;
+  }
+
+  public boolean isEntryEqualTo(final Indexed<ZeebeEntry> indexed, final Indexed<ZeebeEntry> other) {
+    return indexed.entry().term() == other.entry().term()
+        && Arrays.equals(indexed.entry().getData(), other.entry().getData());
   }
 
   public <T> T await(final Supplier<Optional<T>> supplier) {

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
@@ -82,7 +82,7 @@ public class ZeebeTestNode {
     return cluster;
   }
 
-  RaftPartitionServer getPartitionServer(final int id) {
+  public RaftPartitionServer getPartitionServer(final int id) {
     return getPartition(id).getServer();
   }
 


### PR DESCRIPTION
## Description

- adds `RaftCommitListener` interface, which is registered and used by the `RaftContext`
- exposes registration of commit listeners through the partition server
- when applying new entries, the entry is also passed to the listeners*

* Note: the listeners are notified in the thread context of the `RaftStateMachine`, and so should not do anything and keep in mind that they are not executed in the same thread as their creator.

* Note: the listeners are notified on apply to avoid having to read the entry again; we could do it sooner as soon as quorum is reached, but then we have to read the entry in order to get the latest position. If we ditch positions we can refactor this and actually just notify the index.

## Related issues

closes #47