### PR TITLE
feat(raft): send heartbeats via different thread

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftMessageContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftMessageContext.java
@@ -36,6 +36,7 @@ class RaftMessageContext {
   final String pollSubject;
   final String voteSubject;
   final String appendSubject;
+  final String leaderHeartbeatSubject;
 
   RaftMessageContext(String prefix) {
     this.prefix = prefix;
@@ -55,6 +56,7 @@ class RaftMessageContext {
     this.pollSubject = getSubject(prefix, "poll");
     this.voteSubject = getSubject(prefix, "vote");
     this.appendSubject = getSubject(prefix, "append");
+    this.leaderHeartbeatSubject = getSubject(prefix, "leaderHeartbeat");
   }
 
   private static String getSubject(String prefix, String type) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftNamespaces.java
@@ -43,6 +43,7 @@ import io.atomix.protocols.raft.protocol.JoinRequest;
 import io.atomix.protocols.raft.protocol.JoinResponse;
 import io.atomix.protocols.raft.protocol.KeepAliveRequest;
 import io.atomix.protocols.raft.protocol.KeepAliveResponse;
+import io.atomix.protocols.raft.protocol.LeaderHeartbeatRequest;
 import io.atomix.protocols.raft.protocol.LeaveRequest;
 import io.atomix.protocols.raft.protocol.LeaveResponse;
 import io.atomix.protocols.raft.protocol.MetadataRequest;
@@ -152,6 +153,7 @@ public final class RaftNamespaces {
       .register(Instant.class)
       .register(Configuration.class)
       .register(ZeebeEntry.class)
+      .register(LeaderHeartbeatRequest.class)
       .build("RaftProtocol");
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/LeaderHeartbeatRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/LeaderHeartbeatRequest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2015-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.protocol;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.atomix.cluster.MemberId;
+import java.util.Objects;
+
+public class LeaderHeartbeatRequest extends AbstractRaftRequest {
+
+  private final long term;
+  private final String leader;
+  private final long commitIndex;
+
+  public LeaderHeartbeatRequest(long term, String leader, long commitIndex) {
+    this.term = term;
+    this.leader = leader;
+    this.commitIndex = commitIndex;
+  }
+
+  /**
+   * Returns a new append request builder.
+   *
+   * @return A new append request builder.
+   */
+  public static LeaderHeartbeatRequest.Builder builder() {
+    return new LeaderHeartbeatRequest.Builder();
+  }
+
+  /**
+   * Returns the requesting node's current term.
+   *
+   * @return The requesting node's current term.
+   */
+  public long term() {
+    return term;
+  }
+
+  /**
+   * Returns the requesting leader address.
+   *
+   * @return The leader's address.
+   */
+  public MemberId leader() {
+    return MemberId.from(leader);
+  }
+
+  /**
+   * Returns the leader's commit index.
+   *
+   * @return The leader commit index.
+   */
+  public long commitIndex() {
+    return commitIndex;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(getClass(), term, leader, commitIndex);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    LeaderHeartbeatRequest that = (LeaderHeartbeatRequest) o;
+    return term == that.term
+        && commitIndex == that.commitIndex
+        && leader.equals(that.leader);
+  }
+
+  @Override
+  public String toString() {
+    return "LeaderHeartbeatRequest{"
+        + "term=" + term
+        + ", leader='" + leader + '\''
+        + ", commitIndex=" + commitIndex
+        + '}';
+  }
+
+  /**
+   * Append request builder.
+   */
+  public static class Builder extends
+      AbstractRaftRequest.Builder<LeaderHeartbeatRequest.Builder, LeaderHeartbeatRequest> {
+
+    private long term;
+    private String leader;
+    private long commitIndex = -1;
+
+    /**
+     * Sets the request term.
+     *
+     * @param term The request term.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code term} is not positive
+     */
+    public LeaderHeartbeatRequest.Builder withTerm(long term) {
+      checkArgument(term > 0, "term must be positive");
+      this.term = term;
+      return this;
+    }
+
+    /**
+     * Sets the request leader.
+     *
+     * @param leader The request leader.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if the {@code leader} is not positive
+     */
+    public LeaderHeartbeatRequest.Builder withLeader(MemberId leader) {
+      this.leader = checkNotNull(leader, "leader cannot be null").id();
+      return this;
+    }
+
+    /**
+     * Sets the request commit index.
+     *
+     * @param commitIndex The request commit index.
+     * @return The append request builder.
+     * @throws IllegalArgumentException if index is not positive
+     */
+    public LeaderHeartbeatRequest.Builder withCommitIndex(long commitIndex) {
+      checkArgument(commitIndex >= 0, "commitIndex must be positive");
+      this.commitIndex = commitIndex;
+      return this;
+    }
+
+    /**
+     * @throws IllegalStateException if the term, log term, log index, commit index, or global index
+     * are not positive, or if entries is null
+     */
+    @Override
+    public LeaderHeartbeatRequest build() {
+      validate();
+      return new LeaderHeartbeatRequest(term, leader, commitIndex);
+    }
+
+    @Override
+    protected void validate() {
+      super.validate();
+      checkArgument(term > 0, "term must be positive");
+      checkNotNull(leader, "leader cannot be null");
+      checkArgument(commitIndex >= 0, "commitIndex must be positive");
+    }
+  }
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/RaftServerProtocol.java
@@ -376,4 +376,18 @@ public interface RaftServerProtocol {
    */
   void unregisterResetListener(SessionId sessionId);
 
+  void leaderHeartbeat(MemberId memberId, LeaderHeartbeatRequest heartbeat);
+
+  /**
+   * Registers an leader heartbeat callback.
+   *
+   * @param leaderHeartbeatRequestConsumer  the consumer to add
+   * @param executor  the executor with which to execute the listener
+   */
+  void registerLeaderHeartbeatHandler(Consumer<LeaderHeartbeatRequest> leaderHeartbeatRequestConsumer, Executor executor);
+
+  /**
+   * Unregisters the leader heartbeat request handler.
+   */
+  void unregisterLeaderHeartbeatHandler();
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractRole.java
@@ -38,7 +38,7 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 public abstract class AbstractRole implements RaftRole {
   protected final Logger log;
   protected final RaftContext raft;
-  private boolean open = true;
+  private volatile boolean open = true;
 
   protected AbstractRole(RaftContext raft) {
     this.raft = raft;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/RaftRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/RaftRole.java
@@ -30,6 +30,7 @@ import io.atomix.protocols.raft.protocol.JoinRequest;
 import io.atomix.protocols.raft.protocol.JoinResponse;
 import io.atomix.protocols.raft.protocol.KeepAliveRequest;
 import io.atomix.protocols.raft.protocol.KeepAliveResponse;
+import io.atomix.protocols.raft.protocol.LeaderHeartbeatRequest;
 import io.atomix.protocols.raft.protocol.LeaveRequest;
 import io.atomix.protocols.raft.protocol.LeaveResponse;
 import io.atomix.protocols.raft.protocol.MetadataRequest;
@@ -181,5 +182,9 @@ public interface RaftRole extends Managed<RaftRole> {
    * @return A completable future to be completed with the request response.
    */
   CompletableFuture<QueryResponse> onQuery(QueryRequest request);
+
+  default void onLeaderHeartbeat(LeaderHeartbeatRequest request) {
+    // default just accepts it
+  }
 
 }


### PR DESCRIPTION
Introduces a new SingleThreadContext which is used by the Leader to send periodically heartbeats to the followers. The followers uses this ThreadContext to received and process these requests. 
There is no response necessary. It is just to keep the cluster alive and stable.

I run in two a high load benchmarks with:
 * 5 nodes
 * 8 partitions
 * 3 replication factor
 * 900 wfi/s + 16 Worker

The benchmarks contains also the latest changes in atomix (flush on commit) and new backpressure in zeebe. The first test contains not the heartbeat fix and the second does. Even on this high load the cluster seem to be really stable, with the fix. In the following table I summarized the results.


| Before |  After |
|-----------|--------|
|![diff-atomix latency](https://user-images.githubusercontent.com/2758593/68187547-3d06fc00-ffa7-11e9-9fbd-1bb309be376b.png)|![atomix-latency](https://user-images.githubusercontent.com/2758593/68187542-3bd5cf00-ffa7-11e9-903b-cf3c1b3e223a.png)|
|![diff-processing](https://user-images.githubusercontent.com/2758593/68187546-3d06fc00-ffa7-11e9-83de-bdd7d9420f1f.png)|![processing](https://user-images.githubusercontent.com/2758593/68187543-3c6e6580-ffa7-11e9-8c58-fd76aba766ff.png)|
|![diff-heartbeats](https://user-images.githubusercontent.com/2758593/68187545-3d06fc00-ffa7-11e9-8ee2-009887d22c7d.png)|![heartbeats](https://user-images.githubusercontent.com/2758593/68187544-3c6e6580-ffa7-11e9-96ca-5519b48da209.png)|

I will run this benchmark for a longer period to see if any problems still exist.
