### PR TITLE
Reduce test execution time of raft tests

### DIFF
--- a/protocols/raft/src/test/resources/logback.xml
+++ b/protocols/raft/src/test/resources/logback.xml
@@ -21,7 +21,7 @@
         </encoder>
     </appender>
 
-    <root level="${root.logging.level:-TRACE}">
+    <root level="${root.logging.level:-DEBUG}">
         <appender-ref ref="STDOUT" />
     </root>
 </configuration>


### PR DESCRIPTION
* snasphots completion will be tried directly without delay - if this fails then it will retried later
* tests mostly append one entry and wait until it is done - this took a while if we want to append 100 entries. Changed that to append all and wait until all appended.
* added some more tests for raft fail over