### PR TITLE
fix(raft): fix partition metrics

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/LeaderMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/LeaderMetrics.java
@@ -24,7 +24,7 @@ public class LeaderMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("append_entries_latency")
           .help("Latency to append an entry to a follower")
-          .labelNames("follower", "partition")
+          .labelNames("follower", "partitionGroupName", "partition")
           .register();
 
   public LeaderMetrics(String partitionName) {
@@ -32,6 +32,6 @@ public class LeaderMetrics extends RaftMetrics {
   }
 
   public void appendComplete(long latencyms, String memberId) {
-    APPEND_LATENCY.labels(memberId, partition).observe(latencyms / 1000f);
+    APPEND_LATENCY.labels(memberId, partitionGroupName, partition).observe(latencyms / 1000f);
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
@@ -20,17 +20,23 @@ import org.slf4j.LoggerFactory;
 public class RaftMetrics {
 
   protected final String partition;
+  protected final String partitionGroupName;
 
   public RaftMetrics(String partitionName) {
     int partitionId;
+    String groupName;
     try {
       final String[] parts = partitionName.split("-");
       partitionId = Integer.parseInt(parts[parts.length - 1]);
+      groupName = parts[0];
     } catch (Exception e) {
       LoggerFactory.getLogger(RaftMetrics.class)
-          .debug("Cannot extract partition id from name {}, defaulting to 0", partitionName);
+          .debug("Cannot extract partition group name and id from {}, defaulting to raft and 0",
+              partitionName);
       partitionId = 0;
+      groupName = "raft";
     }
     this.partition = String.valueOf(partitionId);
+    this.partitionGroupName = groupName;
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRequestMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRequestMetrics.java
@@ -24,7 +24,7 @@ public class RaftRequestMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("raft_messages_received")
           .help("Number of raft requests received")
-          .labelNames("type", "partition")
+          .labelNames("type", "partitionGroupName", "partition")
           .register();
 
   private static final Counter RAFT_MESSAGES_SEND =
@@ -32,7 +32,7 @@ public class RaftRequestMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("raft_messages_send")
           .help("Number of raft requests send")
-          .labelNames("to", "type", "partition")
+          .labelNames("to", "type", "partitionGroupName", "partition")
           .register();
 
   public RaftRequestMetrics(String partitionName) {
@@ -40,10 +40,10 @@ public class RaftRequestMetrics extends RaftMetrics {
   }
 
   public void receivedMessage(String type) {
-    RAFT_MESSAGES_RECEIVED.labels(type, partition).inc();
+    RAFT_MESSAGES_RECEIVED.labels(type, partitionGroupName, partition).inc();
   }
 
   public void sendMessage(String memberId, String type) {
-    RAFT_MESSAGES_SEND.labels(memberId, type, partition).inc();
+    RAFT_MESSAGES_SEND.labels(memberId, type, partitionGroupName, partition).inc();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
@@ -26,7 +26,7 @@ public class RaftRoleMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("role")
           .help("Shows current role")
-          .labelNames("partition")
+          .labelNames("partitionGroupName", "partition")
           .register();
 
   private static final Counter HEARTBEAT_MISS =
@@ -34,7 +34,7 @@ public class RaftRoleMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("heartbeat_miss_count")
           .help("Count of missing heartbeats")
-          .labelNames("partition")
+          .labelNames("partitionGroupName", "partition")
           .register();
 
   private static final Histogram HEARTBEAT_TIME =
@@ -42,7 +42,7 @@ public class RaftRoleMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("heartbeat_time_in_s")
           .help("Time between heartbeats")
-          .labelNames("partition")
+          .labelNames("partitionGroupName", "partition")
           .register();
 
   public RaftRoleMetrics(String partitionName) {
@@ -50,22 +50,22 @@ public class RaftRoleMetrics extends RaftMetrics {
   }
 
   public void becomingFollower() {
-    ROLE.labels(partition).set(1);
+    ROLE.labels(partitionGroupName, partition).set(1);
   }
 
   public void becomingCandidate() {
-    ROLE.labels(partition).set(2);
+    ROLE.labels(partitionGroupName, partition).set(2);
   }
 
   public void becomingLeader() {
-    ROLE.labels(partition).set(3);
+    ROLE.labels(partitionGroupName, partition).set(3);
   }
 
   public void countHeartbeatMiss() {
-    HEARTBEAT_MISS.labels(partition).inc();
+    HEARTBEAT_MISS.labels(partitionGroupName, partition).inc();
   }
 
   public void observeHeartbeatInterval(long milliseconds) {
-    HEARTBEAT_TIME.labels(partition).observe(milliseconds / 1000f);
+    HEARTBEAT_TIME.labels(partitionGroupName, partition).observe(milliseconds / 1000f);
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftServiceMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftServiceMetrics.java
@@ -24,7 +24,7 @@ public class RaftServiceMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("snapshot_time_ms")
           .help("Time spend to take a snapshot")
-          .labelNames("partition")
+          .labelNames("partitionGroupName", "partition")
           .register();
 
   private static final Histogram COMPACTION_TIME =
@@ -32,7 +32,7 @@ public class RaftServiceMetrics extends RaftMetrics {
           .namespace("atomix")
           .name("compaction_time_ms")
           .help("Time spend to compact")
-          .labelNames("partition")
+          .labelNames("partitionGroupName", "partition")
           .register();
 
   public RaftServiceMetrics(String partitionName) {
@@ -41,10 +41,10 @@ public class RaftServiceMetrics extends RaftMetrics {
 
   public void snapshotTime(long latencyms) {
     // Historgram class expect seconds not milliseconds, for that we need to divied by 1000
-    SNAPSHOTING_TIME.labels(partition).observe(latencyms / 1000f);
+    SNAPSHOTING_TIME.labels(partitionGroupName, partition).observe(latencyms / 1000f);
   }
 
   public void compactionTime(long latencyms) {
-    COMPACTION_TIME.labels(partition).observe(latencyms / 1000f);
+    COMPACTION_TIME.labels(partitionGroupName, partition).observe(latencyms / 1000f);
   }
 }


### PR DESCRIPTION
Currently the system partition and the raft-atomix-partition both start with index one. 


![leaders](https://user-images.githubusercontent.com/2758593/68575928-632c1080-046d-11ea-84b3-e8a449b31389.png)

This is problematic with the current metrics and on the grafana dashboard, because it seems that we have two leader for partition one, until we take a look at the log.

```
2019-11-09 14:32:37.633 CET
zeebe-2
2019-11-09 13:32:37.632 [] [raft-server-2-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 1
2019-11-09 14:33:38.743 CET
zeebe-2
2019-11-09 13:33:38.743 [] [raft-server-2-raft-atomix-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{raft-atomix-partition-1} - Found leader 1
2019-11-09 14:58:17.507 CET
zeebe-2
2019-11-09 13:58:17.507 [] [raft-server-2-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 2
2019-11-09 14:58:17.547 CET
zeebe-4
2019-11-09 13:58:17.547 [] [raft-server-4-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 2
2019-11-09 14:58:17.576 CET
zeebe-0
2019-11-09 13:58:17.576 [] [raft-server-0-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 2
2019-11-09 14:58:17.595 CET
zeebe-3
2019-11-09 13:58:17.595 [] [raft-server-3-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 2
2019-11-09 14:58:18.122 CET
zeebe-0
2019-11-09 13:58:18.122 [] [raft-server-0-raft-atomix-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{raft-atomix-partition-1} - Found leader 0
2019-11-09 14:58:19.344 CET
zeebe-2
2019-11-09 13:58:19.344 [] [raft-server-2-raft-atomix-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{raft-atomix-partition-1} - Found leader 0
2019-11-09 14:59:30.862 CET
zeebe-1
2019-11-09 13:59:30.862 [] [raft-server-1-system-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{system-partition-1} - Found leader 2
2019-11-09 15:00:36.885 CET
zeebe-1
2019-11-09 14:00:36.884 [] [raft-server-1-raft-atomix-partition-1] INFO io.atomix.protocols.raft.impl.RaftContext - RaftServer{raft-atomix-partition-1} - Found leader 0
```