### PR TITLE
chore(raft): repeatedly try to join

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/cluster/impl/RaftClusterContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/cluster/impl/RaftClusterContext.java
@@ -456,8 +456,10 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
                     // in a state that was incapable of handling the join request. Attempt to join
                     // the leader
                     // again after an election timeout.
-                    log.debug("Failed to join {}", member.getMember().memberId());
-                    resetJoinTimer();
+                    log.debug(
+                        "Failed to join {}, probably leader but currently not able to accept the join request. Retry later.",
+                        member.getMember().memberId());
+                    join(getActiveMemberStates().iterator());
                   } else {
                     // If the response error was non-null, attempt to join via the next server in
                     // the members list.
@@ -476,7 +478,7 @@ public final class RaftClusterContext implements RaftCluster, AutoCloseable {
     // for servers to potentially timeout and elect a leader.
     else {
       log.debug("Failed to join cluster, retrying...");
-      resetJoinTimer();
+      join(getActiveMemberStates().iterator());
     }
   }
 


### PR DESCRIPTION
 * in some situations we wait 2 * election timeout before rescheduling join
 * this can take a while; atomix sets the election timeout to 2.5 seconds
 * this reduce the start up time and keep the node doing something (RaftTest execution went from 3.5 minutes to 2.5)

Let me know what you think.