### PR TITLE
chore(raft): migrate InstallRequest#data to ByteBuffer

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultBackupInput.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultBackupInput.java
@@ -20,7 +20,7 @@ import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.BufferInput;
 import io.atomix.storage.buffer.Bytes;
 import io.atomix.utils.serializer.Serializer;
-
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -87,6 +87,12 @@ public class DefaultBackupInput implements BackupInput {
 
   @Override
   public BackupInput read(Buffer buffer) {
+    input.read(buffer);
+    return this;
+  }
+
+  @Override
+  public BackupInput read(final ByteBuffer buffer) {
     input.read(buffer);
     return this;
   }

--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultBackupOutput.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultBackupOutput.java
@@ -21,6 +21,7 @@ import io.atomix.storage.buffer.BufferOutput;
 import io.atomix.storage.buffer.Bytes;
 import io.atomix.utils.serializer.Serializer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -49,6 +50,12 @@ public class DefaultBackupOutput implements BackupOutput {
 
   @Override
   public BackupOutput write(byte[] bytes) {
+    output.write(bytes);
+    return this;
+  }
+
+  @Override
+  public BackupOutput write(final ByteBuffer bytes) {
     output.write(bytes);
     return this;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftMetrics.java
@@ -31,7 +31,8 @@ public class RaftMetrics {
       groupName = parts[0];
     } catch (Exception e) {
       LoggerFactory.getLogger(RaftMetrics.class)
-          .debug("Cannot extract partition group name and id from {}, defaulting to raft and 0",
+          .debug(
+              "Cannot extract partition group name and id from {}, defaulting to raft and 0",
               partitionName);
       partitionId = 0;
       groupName = "raft";

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/protocol/InstallRequest.java
@@ -19,9 +19,9 @@ import static com.google.common.base.MoreObjects.toStringHelper;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.MoreObjects;
 import io.atomix.cluster.MemberId;
-import io.atomix.utils.misc.ArraySizeHashPrinter;
-import java.util.Arrays;
+import java.nio.ByteBuffer;
 import java.util.Objects;
 
 /**
@@ -43,19 +43,19 @@ public class InstallRequest extends AbstractRaftRequest {
   private final long timestamp;
   private final int version;
   private final int offset;
-  private final byte[] data;
+  private final ByteBuffer data;
   private final boolean complete;
 
   public InstallRequest(
-      long term,
-      MemberId leader,
-      long index,
-      long snapshotTerm,
-      long timestamp,
-      int version,
-      int offset,
-      byte[] data,
-      boolean complete) {
+      final long term,
+      final MemberId leader,
+      final long index,
+      final long snapshotTerm,
+      final long timestamp,
+      final int version,
+      final int offset,
+      final ByteBuffer data,
+      final boolean complete) {
     this.term = term;
     this.leader = leader;
     this.index = index;
@@ -144,7 +144,7 @@ public class InstallRequest extends AbstractRaftRequest {
    *
    * @return The snapshot data.
    */
-  public byte[] data() {
+  public ByteBuffer data() {
     return data;
   }
 
@@ -163,7 +163,7 @@ public class InstallRequest extends AbstractRaftRequest {
   }
 
   @Override
-  public boolean equals(Object object) {
+  public boolean equals(final Object object) {
     if (object instanceof InstallRequest) {
       final InstallRequest request = (InstallRequest) object;
       return request.term == term
@@ -172,7 +172,7 @@ public class InstallRequest extends AbstractRaftRequest {
           && request.offset == offset
           && request.complete == complete
           && request.snapshotTerm == snapshotTerm
-          && Arrays.equals(request.data, data);
+          && request.data.equals(data);
     }
     return false;
   }
@@ -187,7 +187,11 @@ public class InstallRequest extends AbstractRaftRequest {
         .add("timestamp", timestamp)
         .add("version", version)
         .add("offset", offset)
-        .add("data", ArraySizeHashPrinter.of(data))
+        .add(
+            "data",
+            MoreObjects.toStringHelper(ByteBuffer.class)
+                .add("size", data.remaining())
+                .add("hash", data.hashCode()))
         .add("complete", complete)
         .toString();
   }
@@ -201,7 +205,7 @@ public class InstallRequest extends AbstractRaftRequest {
     private long timestamp;
     private int version;
     private int offset;
-    private byte[] data;
+    private ByteBuffer data;
     private boolean complete;
     private long snapshotTerm;
 
@@ -212,7 +216,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @return The append request builder.
      * @throws IllegalArgumentException if the {@code term} is not positive
      */
-    public Builder withTerm(long term) {
+    public Builder withTerm(final long term) {
       checkArgument(term > 0, "term must be positive");
       this.term = term;
       return this;
@@ -225,12 +229,12 @@ public class InstallRequest extends AbstractRaftRequest {
      * @return The append request builder.
      * @throws IllegalArgumentException if the {@code leader} is not positive
      */
-    public Builder withLeader(MemberId leader) {
+    public Builder withLeader(final MemberId leader) {
       this.leader = checkNotNull(leader, "leader cannot be null");
       return this;
     }
 
-    public Builder withSnapshotTerm(long term) {
+    public Builder withSnapshotTerm(final long term) {
       checkArgument(term > 0, "snapshotTerm must be positive");
       this.snapshotTerm = term;
       return this;
@@ -242,7 +246,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @param index The request index.
      * @return The request builder.
      */
-    public Builder withIndex(long index) {
+    public Builder withIndex(final long index) {
       checkArgument(index >= 0, "index must be positive");
       this.index = index;
       return this;
@@ -254,7 +258,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @param timestamp The request timestamp.
      * @return The request builder.
      */
-    public Builder withTimestamp(long timestamp) {
+    public Builder withTimestamp(final long timestamp) {
       checkArgument(timestamp >= 0, "timestamp must be positive");
       this.timestamp = timestamp;
       return this;
@@ -266,7 +270,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @param version the request version
      * @return the request builder
      */
-    public Builder withVersion(int version) {
+    public Builder withVersion(final int version) {
       checkArgument(version > 0, "version must be positive");
       this.version = version;
       return this;
@@ -278,7 +282,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @param offset The request offset.
      * @return The request builder.
      */
-    public Builder withOffset(int offset) {
+    public Builder withOffset(final int offset) {
       checkArgument(offset >= 0, "offset must be positive");
       this.offset = offset;
       return this;
@@ -290,7 +294,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @param data The snapshot bytes.
      * @return The request builder.
      */
-    public Builder withData(byte[] data) {
+    public Builder withData(final ByteBuffer data) {
       this.data = checkNotNull(data, "data cannot be null");
       return this;
     }
@@ -302,7 +306,7 @@ public class InstallRequest extends AbstractRaftRequest {
      * @return The request builder.
      * @throws NullPointerException if {@code member} is null
      */
-    public Builder withComplete(boolean complete) {
+    public Builder withComplete(final boolean complete) {
       this.complete = complete;
       return this;
     }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotReader.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotReader.java
@@ -23,6 +23,7 @@ import io.atomix.storage.StorageLevel;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.BufferInput;
 import io.atomix.storage.buffer.Bytes;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -88,6 +89,11 @@ public class SnapshotReader implements BufferInput<SnapshotReader> {
 
   @Override
   public SnapshotReader read(Bytes bytes) {
+    buffer.read(bytes);
+    return this;
+  }
+
+  public SnapshotReader read(ByteBuffer bytes) {
     buffer.read(bytes);
     return this;
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotWriter.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotWriter.java
@@ -23,6 +23,7 @@ import io.atomix.storage.StorageLevel;
 import io.atomix.storage.buffer.Buffer;
 import io.atomix.storage.buffer.BufferOutput;
 import io.atomix.storage.buffer.Bytes;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -73,6 +74,12 @@ public class SnapshotWriter implements BufferOutput<SnapshotWriter> {
 
   @Override
   public SnapshotWriter write(byte[] bytes) {
+    buffer.write(bytes);
+    return this;
+  }
+
+  @Override
+  public SnapshotWriter write(final ByteBuffer bytes) {
     buffer.write(bytes);
     return this;
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1525,8 +1525,7 @@ public class RaftTest extends ConcurrentTestCase {
     final RaftServer server = createServer(members.get(0).memberId());
     server.join(memberIds).get(15_000, TimeUnit.MILLISECONDS);
 
-    final SnapshotStore snapshotStore =
-        server.getContext().getStorage().getSnapshotStore();
+    final SnapshotStore snapshotStore = server.getContext().getStorage().getSnapshotStore();
 
     waitUntil(() -> snapshotStore.getCurrentSnapshot() != null, 100);
 

--- a/storage/src/main/java/io/atomix/storage/buffer/AbstractBuffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/AbstractBuffer.java
@@ -20,6 +20,7 @@ import io.atomix.utils.memory.Memory;
 
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.InvalidMarkException;
 import java.nio.charset.Charset;
@@ -471,6 +472,12 @@ public abstract class AbstractBuffer implements Buffer {
   }
 
   @Override
+  public Buffer read(final ByteBuffer buffer) {
+    this.bytes.read(checkRead(buffer.remaining()), buffer, buffer.position(), buffer.remaining());
+    return this;
+  }
+
+  @Override
   public Buffer read(Bytes bytes) {
     this.bytes.read(checkRead(bytes.size()), bytes, 0, bytes.size());
     return this;
@@ -503,6 +510,13 @@ public abstract class AbstractBuffer implements Buffer {
   @Override
   public Buffer read(int srcOffset, byte[] bytes, int dstOffset, int length) {
     this.bytes.read(checkRead(srcOffset, length), bytes, dstOffset, length);
+    return this;
+  }
+
+  @Override
+  public Buffer read(final int offset, final ByteBuffer dst, final int dstOffset,
+      final int length) {
+    this.bytes.read(checkRead(offset, length), dst, dstOffset, length);
     return this;
   }
 
@@ -708,6 +722,20 @@ public abstract class AbstractBuffer implements Buffer {
   @Override
   public Buffer write(byte[] bytes) {
     this.bytes.write(checkWrite(bytes.length), bytes, 0, bytes.length);
+    return this;
+  }
+
+  @Override
+  public Buffer write(final ByteBuffer src) {
+    final int length = src.remaining();
+    this.bytes.write(checkWrite(length), src, src.position(), length);
+    return this;
+  }
+
+  @Override
+  public Buffer write(final int offset, final ByteBuffer src, final int srcOffset,
+      final int length) {
+    this.bytes.write(checkWrite(offset, length), src, srcOffset, length);
     return this;
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/Buffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/Buffer.java
@@ -16,7 +16,7 @@
 package io.atomix.storage.buffer;
 
 import io.atomix.utils.concurrent.ReferenceCounted;
-
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
@@ -908,6 +908,44 @@ public interface Buffer extends BytesInput<Buffer>, BufferInput<Buffer>, BytesOu
    */
   @Override
   Buffer write(byte[] bytes);
+
+  /**
+   * Writes the remaining bytes of the given buffer into this buffer, from the given buffer's {@link
+   * ByteBuffer#position()} to its {@link ByteBuffer#limit()}
+   *
+   * <p>When the bytes are written to the buffer, the buffer's {@code position} will be advanced by
+   * the number of bytes in the provided byte array. If the number of bytes exceeds {@link
+   * Buffer#limit()} then an {@link java.nio.BufferOverflowException} will be thrown.
+   *
+   * @param bytes the bytes to write
+   * @return the written buffer.
+   * @throws java.nio.BufferOverflowException if the number of bytes exceeds the buffer's remaining
+   *     bytes.
+   * @see Buffer#write(int, ByteBuffer, int, int)
+   */
+  Buffer write(ByteBuffer bytes);
+
+  /**
+   * Writes the {@code length} bytes from the {@code src}, starting at {@code srcOffset} into this
+   * buffer.
+   *
+   * <p>The bytes will be written starting at the given offset up to the given length. If the
+   * remaining bytes in the buffer is larger than the provided {@code length} then only {@code
+   * length} bytes will be read from the array. If the provided {@code length} is greater than
+   * {@link Buffer#limit()} minus {@code offset} then a {@link java.nio.BufferOverflowException}
+   * will be thrown.
+   *
+   * @param offset The offset at which to start writing the bytes.
+   * @param src The source buffer to write.
+   * @param srcOffset The offset at which to begin reading bytes from the source.
+   * @param length The number of bytes from the provided byte array to write to the buffer.
+   * @return The written buffer.
+   * @throws java.nio.BufferOverflowException If there are not enough bytes remaining in the buffer.
+   * @throws IndexOutOfBoundsException If the given offset is out of the bounds of the buffer.
+   * @see Buffer#write(ByteBuffer)
+   */
+  @Override
+  Buffer write(int offset, ByteBuffer src, int srcOffset, int length);
 
   /**
    * Writes an array of bytes to the buffer.

--- a/storage/src/main/java/io/atomix/storage/buffer/BufferInput.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/BufferInput.java
@@ -15,14 +15,16 @@
  */
 package io.atomix.storage.buffer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.function.Function;
 
 /**
  * Readable buffer.
- * <p>
- * This interface exposes methods for reading from a byte buffer. Readable buffers maintain a small amount of state
- * regarding current cursor positions and limits similar to the behavior of {@link java.nio.ByteBuffer}.
+ *
+ * <p>This interface exposes methods for reading from a byte buffer. Readable buffers maintain a
+ * small amount of state regarding current cursor positions and limits similar to the behavior of
+ * {@link java.nio.ByteBuffer}.
  *
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
@@ -30,9 +32,10 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
 
   /**
    * Returns the buffer's current read/write position.
-   * <p>
-   * The position is an internal cursor that tracks where to write/read bytes in the underlying storage implementation.
-   * As bytes are written to or read from the buffer, the position will advance based on the number of bytes read.
+   *
+   * <p>The position is an internal cursor that tracks where to write/read bytes in the underlying
+   * storage implementation. As bytes are written to or read from the buffer, the position will
+   * advance based on the number of bytes read.
    *
    * @return The buffer's current position.
    */
@@ -79,7 +82,7 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
   /**
    * Reads bytes into the given byte array starting at the current position.
    *
-   * @param bytes  The byte array into which to read bytes.
+   * @param bytes The byte array into which to read bytes.
    * @param offset The offset at which to write bytes into the given buffer
    * @return The buffer.
    */
@@ -88,7 +91,7 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
   /**
    * Reads bytes into the given byte array starting at current position up to the given length.
    *
-   * @param bytes  The byte array into which to read bytes.
+   * @param bytes The byte array into which to read bytes.
    * @param offset The offset at which to write bytes into the given buffer
    * @return The buffer.
    */
@@ -101,6 +104,15 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
    * @return The buffer.
    */
   T read(Buffer buffer);
+
+  /**
+   * Reads bytes into the given buffer; it will start writing at the current position and will
+   * advance the position, mutating this buffer.
+   *
+   * @param buffer the destination buffer
+   * @return the buffer input
+   */
+  T read(ByteBuffer buffer);
 
   /**
    * Reads an object from the buffer.
@@ -241,5 +253,4 @@ public interface BufferInput<T extends BufferInput<?>> extends AutoCloseable {
 
   @Override
   void close();
-
 }

--- a/storage/src/main/java/io/atomix/storage/buffer/BufferOutput.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/BufferOutput.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.function.Function;
 
@@ -43,6 +44,8 @@ public interface BufferOutput<T extends BufferOutput<?>> extends AutoCloseable {
    * @return The written buffer.
    */
   T write(byte[] bytes);
+
+  T write(ByteBuffer bytes);
 
   /**
    * Writes an array of bytes to the buffer.

--- a/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBytes.java
@@ -15,10 +15,10 @@
  */
 package io.atomix.storage.buffer;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-
-import static com.google.common.base.Preconditions.checkNotNull;
 
 /**
  * Byte buffer bytes.
@@ -121,6 +121,15 @@ public abstract class ByteBufferBytes extends AbstractBytes {
   }
 
   @Override
+  public Bytes read(final int offset, final ByteBuffer dst, final int dstOffset, final int length) {
+    for (int i = 0; i < length; i++) {
+      dst.put(dstOffset + i, (byte)readByte(offset + i));
+    }
+
+    return this;
+  }
+
+  @Override
   public Bytes read(int position, Bytes bytes, int offset, int length) {
     for (int i = 0; i < length; i++) {
       bytes.writeByte(offset + i, readByte(position + i));
@@ -132,6 +141,15 @@ public abstract class ByteBufferBytes extends AbstractBytes {
   public Bytes write(int position, byte[] bytes, int offset, int length) {
     for (int i = 0; i < length; i++) {
       buffer.put((int) position + i, (byte) bytes[index(offset) + i]);
+    }
+    return this;
+  }
+
+  @Override
+  public Bytes write(
+      final int offset, final ByteBuffer src, final int srcOffset, final int length) {
+    for (int i = 0; i < length; i++) {
+      buffer.put(offset + i, src.get(srcOffset + i));
     }
     return this;
   }

--- a/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/ByteBufferBytes.java
@@ -123,7 +123,7 @@ public abstract class ByteBufferBytes extends AbstractBytes {
   @Override
   public Bytes read(final int offset, final ByteBuffer dst, final int dstOffset, final int length) {
     for (int i = 0; i < length; i++) {
-      dst.put(dstOffset + i, (byte)readByte(offset + i));
+      dst.put(dstOffset + i, (byte) readByte(offset + i));
     }
 
     return this;

--- a/storage/src/main/java/io/atomix/storage/buffer/BytesInput.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/BytesInput.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -47,6 +48,17 @@ public interface BytesInput<T extends BytesInput<T>> {
    * @return The buffer.
    */
   T read(int offset, byte[] dst, int dstOffset, int length);
+
+  /**
+   * Reads bytes into the given byte buffer starting at the given offset up to the given length.
+   *
+   * @param offset    The offset from which to start reading bytes.
+   * @param dst       The byte buffer into which to read bytes.
+   * @param dstOffset The offset at which to write bytes into the given buffer
+   * @param length    The total number of bytes to read.
+   * @return the input buffer
+   */
+  T read(int offset, ByteBuffer dst, int dstOffset, int length);
 
   /**
    * Reads a byte from the buffer at the given offset.

--- a/storage/src/main/java/io/atomix/storage/buffer/BytesOutput.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/BytesOutput.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 
 /**
@@ -71,6 +72,17 @@ public interface BytesOutput<T extends BytesOutput<T>> {
    * @return The written buffer.
    */
   T write(int offset, byte[] src, int srcOffset, int length);
+
+  /**
+   * Writes an array of bytes to the buffer.
+   *
+   * @param offset    The offset at which to start writing the bytes.
+   * @param src       The byte buffer to write.
+   * @param srcOffset The offset at which to start reading bytes from the given source.
+   * @param length    The number of bytes from the provided byte array to write to the buffer.
+   * @return The written buffer.
+   */
+  T write(int offset, ByteBuffer src, int srcOffset, int length);
 
   /**
    * Writes a byte to the buffer at the given offset.

--- a/storage/src/main/java/io/atomix/storage/buffer/ReadOnlyBuffer.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/ReadOnlyBuffer.java
@@ -16,7 +16,7 @@
 package io.atomix.storage.buffer;
 
 import io.atomix.utils.concurrent.ReferenceManager;
-
+import java.nio.ByteBuffer;
 import java.nio.ReadOnlyBufferException;
 
 /**
@@ -119,12 +119,23 @@ public class ReadOnlyBuffer extends AbstractBuffer {
   }
 
   @Override
+  public Buffer write(ByteBuffer src) {
+    throw new ReadOnlyBufferException();
+  }
+
+  @Override
   public Buffer write(byte[] bytes, int offset, int length) {
     throw new ReadOnlyBufferException();
   }
 
   @Override
   public Buffer write(int offset, byte[] bytes, int srcOffset, int length) {
+    throw new ReadOnlyBufferException();
+  }
+
+  @Override
+  public Buffer write(
+      final int offset, final ByteBuffer src, final int srcOffset, final int length) {
     throw new ReadOnlyBufferException();
   }
 

--- a/storage/src/main/java/io/atomix/storage/buffer/WrappedBytes.java
+++ b/storage/src/main/java/io/atomix/storage/buffer/WrappedBytes.java
@@ -15,6 +15,7 @@
  */
 package io.atomix.storage.buffer;
 
+import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
 /**
@@ -82,6 +83,12 @@ public class WrappedBytes extends AbstractBytes {
 
   @Override
   public Bytes read(int offset, byte[] dst, int dstOffset, int length) {
+    bytes.read(offset, dst, dstOffset, length);
+    return this;
+  }
+
+  @Override
+  public Bytes read(final int offset, final ByteBuffer dst, final int dstOffset, final int length) {
     bytes.read(offset, dst, dstOffset, length);
     return this;
   }
@@ -169,6 +176,13 @@ public class WrappedBytes extends AbstractBytes {
 
   @Override
   public Bytes write(int offset, byte[] src, int srcOffset, int length) {
+    bytes.write(offset, src, srcOffset, length);
+    return this;
+  }
+
+  @Override
+  public Bytes write(
+      final int offset, final ByteBuffer src, final int srcOffset, final int length) {
     bytes.write(offset, src, srcOffset, length);
     return this;
   }


### PR DESCRIPTION
In preparation for a pluggable snapshot replication mechanism, I migrated the data member of the install requests to `ByteBuffer`, which will allow us to avoid copying things to and from byte arrays.

Note: this is based on #61 so should be reviewed after (I'll update the branch accordingly).