### PR TITLE
test(raft): add test to verify heartbeats

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/metrics/RaftRoleMetrics.java
@@ -68,4 +68,8 @@ public class RaftRoleMetrics extends RaftMetrics {
   public void observeHeartbeatInterval(long milliseconds) {
     HEARTBEAT_TIME.labels(partitionGroupName, partition).observe(milliseconds / 1000f);
   }
+
+  public static double getHeartbeatMissCount(String partition) {
+    return HEARTBEAT_MISS.labels(partition, partition).get();
+  }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -15,8 +15,10 @@
  */
 package io.atomix.protocols.raft;
 
+import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
@@ -43,6 +45,7 @@ import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.cluster.RaftClusterEvent;
 import io.atomix.protocols.raft.cluster.RaftMember;
 import io.atomix.protocols.raft.cluster.impl.DefaultRaftMember;
+import io.atomix.protocols.raft.metrics.RaftRoleMetrics;
 import io.atomix.protocols.raft.primitive.FakeStateMachine;
 import io.atomix.protocols.raft.primitive.TestMember;
 import io.atomix.protocols.raft.primitive.TestPrimitive;
@@ -1384,6 +1387,32 @@ public class RaftTest extends ConcurrentTestCase {
 
     primitive3.write("foo").thenCompose(v -> primitive3.read()).thenRun(this::resume);
     await(5000);
+  }
+
+  @Test
+  public void testThreeNodeManyEventsDoNotMissHeartbeats() throws Throwable {
+    // given
+    createServers(3);
+
+    final RaftClient client = createClient();
+    final TestPrimitive primitive = createPrimitive(client);
+    primitive.onEvent(
+        message -> {
+          threadAssertNotNull(message);
+          resume();
+        });
+
+    final double startMissedHeartBeats = RaftRoleMetrics.getHeartbeatMissCount("1");
+
+    // when
+    for (int i = 0; i < 1_000; i++) {
+      primitive.sendEvent(true);
+    }
+    await(10000, 1_000);
+
+    // then
+    final double missedHeartBeats = RaftRoleMetrics.getHeartbeatMissCount("1");
+    assertThat(0.0, is(missedHeartBeats - startMissedHeartBeats));
   }
 
   @Test


### PR DESCRIPTION
Just wanted to have an test such that we make sure that the heartbeats are always sent.
Not 100% sure if it makes sense to write this based on the metrics. What do you think?

closes #https://github.com/zeebe-io/atomix/issues/40