### PR TITLE
fix(raft): do not install snapshots on leader

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -28,6 +28,7 @@ import io.atomix.primitive.session.SessionId;
 import io.atomix.primitive.session.SessionMetadata;
 import io.atomix.protocols.raft.RaftException;
 import io.atomix.protocols.raft.RaftServer;
+import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.RaftStateMachine;
 import io.atomix.protocols.raft.metrics.RaftServiceMetrics;
 import io.atomix.protocols.raft.service.RaftServiceContext;
@@ -199,7 +200,7 @@ public class RaftServiceManager implements RaftStateMachine {
               // operation.
               // If the snapshot is for the prior index, install it.
               final Snapshot snapshot = raft.getSnapshotStore().getCurrentSnapshot();
-              if (snapshot != null) {
+              if (raft.getRole() != Role.LEADER && snapshot != null) {
                 if (snapshot.index() >= entry.index()) {
                   future.complete(null);
                   return;


### PR DESCRIPTION
 * the leader took snapshots and directly after that recreates his primitive and applies the
   snapshots, which is not necessary this causes also problems on the PrimitiveClients (session timeouts etc), which cause this https://github.com/zeebe-io/zeebe/issues/3370

Long running looks much better with this change:

![no-leader-install-steady-load](https://user-images.githubusercontent.com/2758593/69030519-1948aa80-09d8-11ea-8063-221c50c481f4.png)


Instead of :

![processing-stopped](https://user-images.githubusercontent.com/2758593/69030612-6167cd00-09d8-11ea-830e-dd24b9f99b9b.png)

Still it can happen, but it is less likely.
