### PR TITLE
fix(raft): take snapshot on same apply index

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftServiceManager.java
@@ -200,11 +200,13 @@ public class RaftServiceManager implements RaftStateMachine {
               // If the snapshot is for the prior index, install it.
               final Snapshot snapshot = raft.getSnapshotStore().getCurrentSnapshot();
               if (snapshot != null) {
-                if (snapshot.index() >= entry.index()) {
+                if (snapshot.index() > entry.index()) {
                   future.complete(null);
                   return;
-                } else if (snapshot.index() == entry.index() - 1) {
+                } else if (snapshot.index() == entry.index()) {
                   install(snapshot);
+                  future.complete(null);
+                  return;
                 }
               }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/RaftStorage.java
@@ -56,7 +56,7 @@ import java.util.function.Predicate;
  *
  * @see RaftLog
  */
-public final class RaftStorage {
+public class RaftStorage {
 
   private final String prefix;
   private final StorageLevel storageLevel;
@@ -73,7 +73,7 @@ public final class RaftStorage {
   private final StorageStatistics statistics;
   private final SnapshotStore snapshotStore;
 
-  private RaftStorage(
+  RaftStorage(
       final String prefix,
       final StorageLevel storageLevel,
       final File directory,


### PR DESCRIPTION
 * on apply an command the snapshot store is checked whether there
 is a valid snapshot for this position or not
 If this is the case the snapshot is applied. Before this was also done
 for the leader, since on the entry after the snapshot the index of the
 previous was compared with the snapshot index. To not install snapshots
 we decided to compare the index with the current index, such that
 followers or leaders which have not created this snapshot are the only one which
 install the snapshot

I did a benchmark with this change and this seems to be stable as the other solution

![install-on-same-idx](https://user-images.githubusercontent.com/2758593/69056896-3057be80-0a11-11ea-8ed0-e8103378ed41.png)
