### PR TITLE
chore(raft): add callbacks onWrite/onCommit when appending

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -377,8 +377,8 @@
               <value>bar</value>
             </property>
           </javaApiLinks>
+          <additionalOptions>-Xdoclint:none</additionalOptions>
           <quiet>true</quiet>
-          <additionalparam>${argLine.javadocs}</additionalparam>
           <show>public</show>
           <doctitle>Atomix API Reference (${jv})</doctitle>
           <windowtitle>Atomix API Reference (${jv})</windowtitle>

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppender.java
@@ -17,8 +17,12 @@ package io.atomix.protocols.raft.zeebe;
 
 import io.atomix.storage.journal.Indexed;
 import java.nio.ByteBuffer;
-import java.util.concurrent.CompletableFuture;
 
+/**
+ * A log appender provides a central entry point to append to the local Raft log such that it is
+ * automatically replicated and eventually committed, and the ability for callers to be notified of
+ * various events, e.g. {@link AppendListener#onCommit(Indexed)}.
+ */
 @FunctionalInterface
 public interface ZeebeLogAppender {
 
@@ -28,8 +32,44 @@ public interface ZeebeLogAppender {
    * @param lowestPosition lowest record position in the data buffer
    * @param highestPosition highest record position in the data buffer
    * @param data data to store in the entry
-   * @return a future which is completed with the indexed entry is committed
    */
-  CompletableFuture<Indexed<ZeebeEntry>> appendEntry(
-      long lowestPosition, long highestPosition, ByteBuffer data);
+  void appendEntry(
+      long lowestPosition, long highestPosition, ByteBuffer data, AppendListener appendListener);
+
+  /**
+   * An append listener can observe and be notified of different events related to the append
+   * operation.
+   */
+  interface AppendListener {
+
+    /**
+     * Called when the entry has been written to the log.
+     *
+     * @param indexed the entry that was written to the log
+     */
+    void onWrite(Indexed<ZeebeEntry> indexed);
+
+    /**
+     * Called when an error occurred while writing the entry to the log.
+     *
+     * @param error the error that occurred
+     */
+    void onWriteError(Throwable error);
+
+    /**
+     * Called when the entry has been committed.
+     *
+     * @param indexed the entry that was committed
+     */
+    void onCommit(Indexed<ZeebeEntry> indexed);
+
+    /**
+     * Called when an error occurred while replicating or committing an entry, typically when if an
+     * append operation was pending when shutting down the server or stepping down as leader.
+     *
+     * @param indexed the entry that should have been committed
+     * @param error the error that occurred
+     */
+    void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error);
+  }
 }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppenderTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/ZeebeLogAppenderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft.zeebe;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.google.common.base.Stopwatch;
+import io.atomix.protocols.raft.zeebe.util.TestAppender;
+import io.atomix.protocols.raft.zeebe.util.ZeebeTestHelper;
+import io.atomix.protocols.raft.zeebe.util.ZeebeTestNode;
+import io.atomix.storage.journal.Indexed;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests the {@link io.atomix.protocols.raft.roles.LeaderRole} implementation of {@link
+ * ZeebeLogAppender}
+ */
+public class ZeebeLogAppenderTest {
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private final Logger logger = LoggerFactory.getLogger(this.getClass());
+  private final Stopwatch stopwatch = Stopwatch.createUnstarted();
+  private final TestAppender appenderListener = new TestAppender();
+
+  private ZeebeTestNode node;
+  private ZeebeTestHelper helper;
+
+  @Before
+  public void setUp() throws Exception {
+    node = new ZeebeTestNode(0, temporaryFolder.newFolder("0"));
+
+    final Set<ZeebeTestNode> nodes = Collections.singleton(node);
+    helper = new ZeebeTestHelper(nodes);
+
+    node.start(nodes).join();
+    stopwatch.start();
+  }
+
+  @After
+  public void tearDown() {
+    if (stopwatch.isRunning()) {
+      stopwatch.stop();
+    }
+
+    logger.info("Test run time: {}", stopwatch.toString());
+    node.stop().join();
+  }
+
+  @Test
+  public void shouldNotifyOnWrite() {
+    // when
+    append();
+
+    // then
+    final Indexed<ZeebeEntry> appended = appenderListener.pollWritten();
+    assertNotNull(appended);
+    assertEquals(0, appenderListener.getErrors().size());
+  }
+
+  @Test
+  public void shouldNotifyOnCommit() {
+    // when
+    append();
+
+    // then
+    final Indexed<ZeebeEntry> appended = appenderListener.pollCommitted();
+    assertNotNull(appended);
+    assertEquals(0, appenderListener.getErrors().size());
+  }
+
+  @Test
+  public void shouldNotifyOnError() {
+    // given - a message that cannot be appended because it's too large
+    final ByteBuffer data = ByteBuffer.allocate(2048);
+
+    // when
+    append(data);
+
+    // then
+    final Throwable error = appenderListener.pollError();
+    assertNotNull(error);
+    assertEquals(0L, appenderListener.getWritten().size());
+    assertEquals(0L, appenderListener.getCommitted().size());
+  }
+
+  private void append() {
+    append(ByteBuffer.allocate(Integer.BYTES).putInt(0, 1));
+  }
+
+  private void append(final ByteBuffer data) {
+    final ZeebeLogAppender appender = helper.awaitLeaderAppender(1);
+    appender.appendEntry(0, 0, data, appenderListener);
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/TestAppender.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/TestAppender.java
@@ -1,0 +1,85 @@
+package io.atomix.protocols.raft.zeebe.util;
+
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeLogAppender;
+import io.atomix.protocols.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.atomix.storage.journal.Indexed;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class TestAppender implements AppendListener {
+  private final BlockingQueue<Indexed<ZeebeEntry>> written;
+  private final BlockingQueue<Indexed<ZeebeEntry>> committed;
+  private final BlockingQueue<Throwable> errors;
+
+  public TestAppender() {
+    this.written = new LinkedBlockingQueue<>();
+    this.committed = new LinkedBlockingQueue<>();
+    this.errors = new LinkedBlockingQueue<>();
+  }
+
+  @Override
+  public void onWrite(final Indexed<ZeebeEntry> indexed) {
+    written.offer(indexed);
+  }
+
+  @Override
+  public void onWriteError(final Throwable error) {
+    errors.offer(error);
+  }
+
+  @Override
+  public void onCommit(final Indexed<ZeebeEntry> indexed) {
+    committed.offer(indexed);
+  }
+
+  @Override
+  public void onCommitError(final Indexed<ZeebeEntry> indexed, final Throwable error) {
+    errors.offer(error);
+  }
+
+  public Indexed<ZeebeEntry> append(
+      final ZeebeLogAppender appender,
+      final long lowest,
+      final long highest,
+      final ByteBuffer data) {
+    appender.appendEntry(lowest, highest, data, this);
+    return pollWritten();
+  }
+
+  public Indexed<ZeebeEntry> pollWritten() {
+    return takeUnchecked(written);
+  }
+
+  public Indexed<ZeebeEntry> pollCommitted() {
+    return takeUnchecked(committed);
+  }
+
+  public Throwable pollError() {
+    return takeUnchecked(errors);
+  }
+
+  public List<Indexed<ZeebeEntry>> getWritten() {
+    return new ArrayList<>(written);
+  }
+
+  public List<Indexed<ZeebeEntry>> getCommitted() {
+    return new ArrayList<>(committed);
+  }
+
+  public List<Throwable> getErrors() {
+    return new ArrayList<>(errors);
+  }
+
+  private <T> T takeUnchecked(final BlockingQueue<T> queue) {
+    try {
+      return queue.take();
+    } catch (final InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/zeebe/util/ZeebeTestNode.java
@@ -127,7 +127,8 @@ public class ZeebeTestNode {
         .withPartitionSize(members.size())
         .withFlushOnCommit()
         .withStorageLevel(StorageLevel.DISK)
-        .withSegmentSize(1024L);
+        .withSegmentSize(1024L)
+        .withMaxEntrySize(512);
   }
 
   public Member getMember() {

--- a/protocols/raft/src/test/resources/logback.xml
+++ b/protocols/raft/src/test/resources/logback.xml
@@ -21,7 +21,9 @@
     </encoder>
   </appender>
 
-  <root level="${root.logging.level:-DEBUG}">
+  <logger name="io.atomix" level="DEBUG" />
+
+  <root level="${root.logging.level:-WARN}">
     <appender-ref ref="STDOUT"/>
   </root>
 </configuration>


### PR DESCRIPTION
- modifies `ZeebeLogAppender#appendEntry` to take in a listener
- adds listener interface which is notified on local write, on commit, and on errors

NOTE: I couldn't figure out how to test that a callback isn't called, since the best I could do was always "it hasn't been called...yet!". I don't see much value adding tests for those as our integration tests should catch these things, but let me know what you think.

Closes #74 