### PR TITLE
chore(raft): add retry on write error

### DIFF
--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/roles/LeaderRoleTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/roles/LeaderRoleTest.java
@@ -1,0 +1,331 @@
+package io.atomix.protocols.raft.roles;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.timeout;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.atomix.protocols.raft.RaftServer.Role;
+import io.atomix.protocols.raft.impl.RaftContext;
+import io.atomix.protocols.raft.storage.log.RaftLogWriter;
+import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeEntry;
+import io.atomix.protocols.raft.zeebe.ZeebeLogAppender.AppendListener;
+import io.atomix.storage.StorageException;
+import io.atomix.storage.journal.Indexed;
+import io.atomix.utils.concurrent.SingleThreadContext;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class LeaderRoleTest {
+
+  private LeaderRole leadeRole;
+  private RaftLogWriter writer;
+  private RaftContext context;
+
+  @Before
+  public void setup() {
+    context = Mockito.mock(RaftContext.class);
+
+    when(context.getName()).thenReturn("leader");
+    when(context.getElectionTimeout()).thenReturn(Duration.ofMillis(100));
+    when(context.getHeartbeatInterval()).thenReturn(Duration.ofMillis(100));
+
+    final SingleThreadContext threadContext = new SingleThreadContext("leader");
+    when(context.getThreadContext()).thenReturn(threadContext);
+
+    writer = mock(RaftLogWriter.class);
+    when(writer.getNextIndex()).thenReturn(1L);
+    when(writer.append(any(ZeebeEntry.class)))
+        .then(
+            i -> {
+              final ZeebeEntry zeebeEntry = i.getArgument(0);
+              return new Indexed<>(1, zeebeEntry, 45);
+            });
+    when(context.getLogWriter()).thenReturn(writer);
+
+    leadeRole = new LeaderRole(context);
+  }
+
+  @Test
+  public void shouldAppendEntry() throws InterruptedException {
+    // given
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {
+            latch.countDown();
+          }
+
+          @Override
+          public void onWriteError(Throwable error) {}
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void shouldRetryAppendEntryOnIOException() throws InterruptedException {
+    // given
+
+    when(writer.append(any(ZeebeEntry.class)))
+        .thenThrow(new StorageException(new IOException()))
+        .thenThrow(new StorageException(new IOException()))
+        .then(
+            i -> {
+              final ZeebeEntry zeebeEntry = i.getArgument(0);
+              return new Indexed<>(1, zeebeEntry, 45);
+            });
+
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {
+            latch.countDown();
+          }
+
+          @Override
+          public void onWriteError(Throwable error) {}
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(writer, timeout(1000).atLeast(3)).append(any(RaftLogEntry.class));
+  }
+
+  @Test
+  public void shouldStopRetryAppendEntryAfterMaxRetries() throws InterruptedException {
+    // given
+    when(writer.append(any(ZeebeEntry.class))).thenThrow(new StorageException(new IOException()));
+
+    final AtomicReference<Throwable> catchedError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onWriteError(Throwable error) {
+            catchedError.set(error);
+            latch.countDown();
+          }
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(writer, timeout(1000).atLeast(5)).append(any(RaftLogEntry.class));
+    verify(context, timeout(1000)).transition(Role.FOLLOWER);
+    assertTrue(catchedError.get() instanceof IOException);
+  }
+
+  @Test
+  public void shouldStopAppendEntryOnOutOfDisk() throws InterruptedException {
+    // given
+    when(writer.append(any(ZeebeEntry.class)))
+        .thenThrow(new StorageException.OutOfDiskSpace("Boom file out"));
+
+    final AtomicReference<Throwable> catchedError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onWriteError(Throwable error) {
+            catchedError.set(error);
+            latch.countDown();
+          }
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(context, timeout(1000)).transition(Role.FOLLOWER);
+    verify(writer, timeout(1000)).append(any(RaftLogEntry.class));
+
+    assertTrue(catchedError.get() instanceof StorageException.OutOfDiskSpace);
+  }
+
+  @Test
+  public void shouldStopAppendEntryOnToLargeEntry() throws InterruptedException {
+    // given
+    when(writer.append(any(ZeebeEntry.class)))
+        .thenThrow(new StorageException.TooLarge("Too large entry"));
+
+    final AtomicReference<Throwable> catchedError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onWriteError(Throwable error) {
+            catchedError.set(error);
+            latch.countDown();
+          }
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(writer, timeout(1000)).append(any(RaftLogEntry.class));
+
+    assertTrue(catchedError.get() instanceof StorageException.TooLarge);
+  }
+
+  @Test
+  public void shouldStopAppendEntryOnAnyOtherException() throws InterruptedException {
+    // given
+    when(writer.append(any(ZeebeEntry.class))).thenThrow(new RuntimeException("expected"));
+
+    final AtomicReference<Throwable> catchedError = new AtomicReference<>();
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final CountDownLatch latch = new CountDownLatch(1);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onWriteError(Throwable error) {
+            catchedError.set(error);
+            latch.countDown();
+          }
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(writer, timeout(1000)).append(any(RaftLogEntry.class));
+
+    assertTrue(catchedError.get() instanceof RuntimeException);
+  }
+
+  @Test
+  public void shouldRetryAppendEntriesInOrder() throws InterruptedException {
+    // given
+
+    when(writer.append(any(ZeebeEntry.class)))
+        .thenThrow(new StorageException(new IOException()))
+        .thenThrow(new StorageException(new IOException()))
+        .then(
+            i -> {
+              final ZeebeEntry zeebeEntry = i.getArgument(0);
+              return new Indexed<>(1, zeebeEntry, 45);
+            });
+
+    final ByteBuffer data = ByteBuffer.allocate(Integer.BYTES).putInt(0, 1);
+    final List<ZeebeEntry> entries = new CopyOnWriteArrayList<>();
+    final CountDownLatch latch = new CountDownLatch(2);
+    final AppendListener listener =
+        new AppendListener() {
+
+          @Override
+          public void onWrite(Indexed<ZeebeEntry> indexed) {
+            entries.add(indexed.entry());
+            latch.countDown();
+          }
+
+          @Override
+          public void onWriteError(Throwable error) {}
+
+          @Override
+          public void onCommit(Indexed<ZeebeEntry> indexed) {}
+
+          @Override
+          public void onCommitError(Indexed<ZeebeEntry> indexed, Throwable error) {}
+        };
+
+    // when
+    leadeRole.appendEntry(0, 1, data, listener);
+    leadeRole.appendEntry(1, 2, data, listener);
+
+    // then
+    latch.await(10, TimeUnit.SECONDS);
+    verify(writer, timeout(1000).atLeast(3)).append(any(RaftLogEntry.class));
+
+    assertEquals(2, entries.size());
+    assertEquals(1, entries.get(0).highestPosition());
+    assertEquals(2, entries.get(1).highestPosition());
+  }
+}


### PR DESCRIPTION
 * retries the append attempt if there was an IOException, until an max retry is reached
 * when the maximum retry is reached we will step down, because we probably have some serious issues with our disk
 * on exceptions like TooLarge or BufferExceptions no retry is done, since it does not make sense we just fail the append attempt
 * on out of disk space we fail the attempt and step down there is nothing we can do in this case

I kept the listener approach for now. Don't want to have to much changes and I think it is still quite interesting to have, but we can discuss this. Maybe we want to add metrics for the writes and errors etc. 

We need to adjust our listener in Zeebe, such that it never retries it just releases the append backpressure on write error.

I run a benchmark with the changes and it looked quite promising.
![atomix-retry](https://user-images.githubusercontent.com/2758593/69865193-d53f8a80-12a0-11ea-8d2b-6b91301cfb29.png)

P.S.: I replaced all the `whenCompleteAsync` with `whenComplete` to reduce the latency of the entry processing. It might be that this was before to run jobs and the ability to send heartbeats in time, but since we have now concurrent heart beats this should be fine.