### PR TITLE
feat(storage): add JournalReader#isEmpty() API

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -18,6 +18,7 @@ package io.atomix.protocols.raft.storage.log;
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.DelegatingJournal;
+import io.atomix.storage.journal.JournalReader;
 import io.atomix.storage.journal.SegmentedJournal;
 import io.atomix.utils.serializer.Namespace;
 import java.io.File;
@@ -51,12 +52,12 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
   @Override
   public RaftLogReader openReader(long index) {
-    return openReader(index, RaftLogReader.Mode.ALL);
+    return openReader(index, JournalReader.Mode.ALL);
   }
 
   @Override
-  public RaftLogReader openReader(long index, RaftLogReader.Mode mode) {
-    return new RaftLogReader(journal.openReader(index, mode), this, mode);
+  public RaftLogReader openReader(long index, JournalReader.Mode mode) {
+    return new RaftLogReader(journal.openReader(index, mode));
   }
 
   /**

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLogReader.java
@@ -17,12 +17,11 @@ package io.atomix.protocols.raft.storage.log;
 
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
 import io.atomix.storage.journal.DelegatingJournalReader;
-import io.atomix.storage.journal.SegmentedJournalReader;
+import io.atomix.storage.journal.JournalReader;
 
 /** Raft log reader. */
 public class RaftLogReader extends DelegatingJournalReader<RaftLogEntry> {
-
-  public RaftLogReader(SegmentedJournalReader<RaftLogEntry> reader, RaftLog log, Mode mode) {
-    super(reader);
+  RaftLogReader(final JournalReader<RaftLogEntry> delegate) {
+    super(delegate);
   }
 }

--- a/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/DelegatingJournalReader.java
@@ -28,6 +28,11 @@ public class DelegatingJournalReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public boolean isEmpty() {
+    return delegate.isEmpty();
+  }
+
+  @Override
   public long getFirstIndex() {
     return delegate.getFirstIndex();
   }

--- a/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/FileChannelJournalSegmentReader.java
@@ -59,6 +59,15 @@ class FileChannelJournalSegmentReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public boolean isEmpty() {
+    try {
+      return channel.size() == 0;
+    } catch (IOException e) {
+      throw new StorageException(e);
+    }
+  }
+
+  @Override
   public long getFirstIndex() {
     return segment.index();
   }

--- a/storage/src/main/java/io/atomix/storage/journal/JournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/JournalReader.java
@@ -41,6 +41,14 @@ public interface JournalReader<E> extends Iterator<Indexed<E>>, AutoCloseable {
   }
 
   /**
+   * Returns true if there is nothing available to read regardless of the current reader position,
+   * meaning even if we reset the reader to any position there would be nothing to read.
+   *
+   * @return true if nothing to read, false otherwise
+   */
+  boolean isEmpty();
+
+  /**
    * Returns the first index in the journal.
    *
    * @return the first index in the journal

--- a/storage/src/main/java/io/atomix/storage/journal/MappableJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/MappableJournalSegmentReader.java
@@ -75,6 +75,11 @@ class MappableJournalSegmentReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public boolean isEmpty() {
+    return reader.isEmpty();
+  }
+
+  @Override
   public long getFirstIndex() {
     return reader.getFirstIndex();
   }

--- a/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
@@ -18,7 +18,6 @@ package io.atomix.storage.journal;
 import io.atomix.storage.journal.index.JournalIndex;
 import io.atomix.storage.journal.index.Position;
 import io.atomix.utils.serializer.Namespace;
-
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.NoSuchElementException;
@@ -50,6 +49,11 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
     this.namespace = namespace;
     this.segment = segment;
     reset();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return buffer.limit() == 0;
   }
 
   @Override
@@ -127,9 +131,7 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
     return currentEntry;
   }
 
-  /**
-   * Reads the next entry in the segment.
-   */
+  /** Reads the next entry in the segment. */
   @SuppressWarnings("unchecked")
   private void readNext() {
     // Compute the index of the next entry in the segment.

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournalReader.java
@@ -50,6 +50,16 @@ public class SegmentedJournalReader<E> implements JournalReader<E> {
   }
 
   @Override
+  public boolean isEmpty() {
+    final JournalSegment<E> firstSegment = journal.getFirstSegment();
+    if (firstSegment.isEmpty()) {
+      return true;
+    }
+
+    return mode == Mode.COMMITS && journal.getCommitIndex() < firstSegment.index();
+  }
+
+  @Override
   public long getFirstIndex() {
     return journal.getFirstSegment().index();
   }


### PR DESCRIPTION
# Description

- provides a way for log readers to distinguish between an empty log and having no more entries to read

# Related issues

Closes #125, [zeebe-io/zeebe#3543](https://github.com/zeebe-io/zeebe/issues/3543#issuecomment-566519318)