### PR TITLE
Expose Raft step down

### DIFF
--- a/core/src/test/java/io/atomix/core/AtomixRule.java
+++ b/core/src/test/java/io/atomix/core/AtomixRule.java
@@ -1,0 +1,144 @@
+package io.atomix.core;
+
+import io.atomix.cluster.Node;
+import io.atomix.cluster.discovery.BootstrapDiscoveryProvider;
+import io.atomix.cluster.discovery.MulticastDiscoveryProvider;
+import io.atomix.core.profile.Profile;
+import io.atomix.utils.net.Address;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.rules.ExternalResource;
+import org.slf4j.LoggerFactory;
+
+public final class AtomixRule extends ExternalResource {
+
+  private static final int BASE_PORT = 5000;
+  private static final File DATA_DIR = new File(System.getProperty("user.dir"), ".data");
+
+  @Override
+  protected void before() throws Throwable {
+    deleteData();
+  }
+
+  @Override
+  protected void after() {
+    try {
+      deleteData();
+    } catch (Exception e) {
+      LoggerFactory.getLogger(AtomixRule.class).error("Unexpected error on clean up data", e);
+    }
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public AtomixBuilder buildAtomix(int id, Properties properties) {
+    return Atomix.builder()
+        .withClusterId("test")
+        .withMemberId(String.valueOf(id))
+        .withHost("localhost")
+        .withPort(BASE_PORT + id)
+        .withProperties(properties)
+        .withMulticastEnabled()
+        .withMembershipProvider(new MulticastDiscoveryProvider());
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public AtomixBuilder buildAtomix(int id, List<Integer> memberIds,
+      Properties properties) {
+    final Collection<Node> nodes = memberIds.stream()
+        .map(memberId -> Node.builder()
+            .withId(String.valueOf(memberId))
+            .withAddress(Address.from("localhost", BASE_PORT + memberId))
+            .build())
+        .collect(Collectors.toList());
+
+    return Atomix.builder()
+        .withClusterId("test")
+        .withMemberId(String.valueOf(id))
+        .withHost("localhost")
+        .withPort(BASE_PORT + id)
+        .withProperties(properties)
+        .withMulticastEnabled()
+        .withMembershipProvider(!nodes.isEmpty() ? new BootstrapDiscoveryProvider(nodes)
+            : new MulticastDiscoveryProvider());
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public Atomix createAtomix(int id, List<Integer> bootstrapIds, Profile... profiles) {
+    return createAtomix(id, bootstrapIds, new Properties(), profiles);
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public Atomix createAtomix(int id, List<Integer> bootstrapIds, Properties properties,
+      Profile... profiles) {
+    return createAtomix(id, bootstrapIds, properties, b -> b.withProfiles(profiles).build());
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public Atomix createAtomix(int id, List<Integer> bootstrapIds,
+      Function<AtomixBuilder, Atomix> builderFunction) {
+    return createAtomix(id, bootstrapIds, new Properties(), builderFunction);
+  }
+
+  /**
+   * Creates an Atomix instance.
+   */
+  public Atomix createAtomix(int id, List<Integer> bootstrapIds, Properties properties,
+      Function<AtomixBuilder, Atomix> builderFunction) {
+    return builderFunction.apply(buildAtomix(id, bootstrapIds, properties));
+  }
+
+  private int findAvailablePort(int defaultPort) {
+    try {
+      final ServerSocket socket = new ServerSocket(0);
+      socket.setReuseAddress(true);
+      final int port = socket.getLocalPort();
+      socket.close();
+      return port;
+    } catch (IOException ex) {
+      return defaultPort;
+    }
+  }
+
+  /**
+   * Deletes data from the test data directory.
+   */
+  private static void deleteData() throws Exception {
+    final Path directory = DATA_DIR.toPath();
+    if (Files.exists(directory)) {
+      Files.walkFileTree(directory, new SimpleFileVisitor<Path>() {
+        @Override
+        public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
+          Files.delete(file);
+          return FileVisitResult.CONTINUE;
+        }
+
+        @Override
+        public FileVisitResult postVisitDirectory(Path dir, IOException exc) throws IOException {
+          Files.delete(dir);
+          return FileVisitResult.CONTINUE;
+        }
+      });
+    }
+  }
+}

--- a/core/src/test/java/io/atomix/core/RaftRolesTest.java
+++ b/core/src/test/java/io/atomix/core/RaftRolesTest.java
@@ -1,0 +1,421 @@
+package io.atomix.core;
+
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import io.atomix.primitive.partition.Partition;
+import io.atomix.primitive.partition.impl.DefaultPartitionService;
+import io.atomix.protocols.raft.RaftServer;
+import io.atomix.protocols.raft.RaftServer.Role;
+import io.atomix.protocols.raft.partition.RaftPartition;
+import io.atomix.protocols.raft.partition.RaftPartitionGroup;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+public final class RaftRolesTest extends AbstractAtomixTest {
+
+  @Rule
+  public AtomixRule atomixRule = new AtomixRule();
+
+  private List<Atomix> instances;
+
+  @Before
+  public void setupInstances() {
+    instances = new ArrayList<>();
+  }
+
+  @After
+  public void teardownInstances() {
+    final List<CompletableFuture<Void>> futures = instances.stream().map(Atomix::stop)
+        .collect(Collectors.toList());
+    try {
+      CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()]))
+          .get(30, TimeUnit.SECONDS);
+    } catch (Exception e) {
+      // Do nothing
+    }
+  }
+
+  @Test
+  public void testRoleChangedListener() throws Exception {
+    // given
+    final CompletableFuture<Void> roleChanged = new CompletableFuture<>();
+
+    // when
+    final CompletableFuture<Atomix> joinFuture = startSingleNodeSinglePartitionWithPartitionConsumer(
+        partition -> {
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener(role -> roleChanged.complete(null));
+        });
+
+    // then
+    joinFuture.join();
+    roleChanged.get();
+  }
+
+  @Test
+  public void testExceptionInRoleChangedListener() throws Exception {
+    // given
+    final CompletableFuture<Void> roleChanged = new CompletableFuture<>();
+
+    final CompletableFuture<Atomix> joinFuture = startSingleNodeSinglePartitionWithPartitionConsumer(
+        partition -> {
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener(role -> {
+            roleChanged.complete(null);
+
+            // when
+            throw new RuntimeException("expected");
+          });
+        });
+
+    // then
+    joinFuture.join();
+    roleChanged.get(60, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testStepDownInRoleChangedListener() throws Exception {
+    // given
+    final CompletableFuture<Void> roleChanged = new CompletableFuture<>();
+    final CountDownLatch followerLatch = new CountDownLatch(2);
+    final List<Role> roles = new ArrayList<>();
+
+    startSingleNodeSinglePartitionWithPartitionConsumer(partition -> {
+      final RaftPartition raftPartition = (RaftPartition) partition;
+      raftPartition.addRoleChangeListener(role -> {
+        roles.add(role);
+        if (!roleChanged.isDone() && role == Role.LEADER) {
+          roleChanged.complete(null);
+
+          // when
+          raftPartition.stepDown();
+        } else if (role == Role.FOLLOWER) {
+          followerLatch.countDown();
+        }
+      });
+    }).join();
+
+    // then
+    roleChanged.get(60, TimeUnit.SECONDS);
+    followerLatch.await(10, TimeUnit.SECONDS);
+
+    // single node becomes directly leader again
+    assertThat(roles, contains(Role.LEADER, Role.LEADER));
+  }
+
+  @Test
+  public void testStepDownOnRoleChangeInCluster() throws Exception {
+    // given
+    // normal distribution
+    // Partitions \ Nodes
+    //      \   0  1  2
+    //    0     L  F  F
+    //    1     F  L  F
+    //    2     F  F  L
+    final CountDownLatch latch = new CountDownLatch(3);
+    final List<Map<Integer, Role>> nodeRoles = new CopyOnWriteArrayList<>();
+    nodeRoles.add(new ConcurrentHashMap<>());
+    nodeRoles.add(new ConcurrentHashMap<>());
+    nodeRoles.add(new ConcurrentHashMap<>());
+
+    final List<Integer> members = Arrays.asList(1, 2, 3);
+
+    final int firstNodeId = 1;
+    final int expectedFirstNodeLeadingPartition = 1;
+    final CompletableFuture<Atomix> nodeOneFuture = startAtomixWithPartitionConsumer(firstNodeId, 3,
+        members,
+        partition -> {
+          final Map<Integer, RaftServer.Role> roleMap = nodeRoles.get(0);
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener((role) -> {
+            final Integer partitionId = partition.id().id();
+            roleMap.put(partitionId, role);
+
+            if (role == Role.LEADER) {
+              if (partitionId == expectedFirstNodeLeadingPartition) {
+                raftPartition.stepDown();
+              } else {
+                latch.countDown();
+              }
+            }
+          });
+        });
+
+    final int secondNodeId = 2;
+    final int expectedSecondNodeLeadingPartition = 2;
+    final CompletableFuture<Atomix> nodeTwoFuture = startAtomixWithPartitionConsumer(secondNodeId,
+        3,
+        members,
+        partition -> {
+          final Map<Integer, RaftServer.Role> roleMap = nodeRoles.get(1);
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener((role) -> {
+            final Integer partitionId = partition.id().id();
+            roleMap.put(partitionId, role);
+
+            if (role == Role.LEADER) {
+              if (partitionId == expectedSecondNodeLeadingPartition) {
+                raftPartition.stepDown();
+              } else {
+                latch.countDown();
+              }
+            }
+          });
+        });
+
+    final int thirdNodeId = 3;
+    final int expectedThirdNodeLeadingPartition = 3;
+    final CompletableFuture<Atomix> nodeThreeFuture = startAtomixWithPartitionConsumer(thirdNodeId,
+        3,
+        members,
+        partition -> {
+          final Map<Integer, RaftServer.Role> roleMap = nodeRoles.get(2);
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener((role) -> {
+            final Integer partitionId = partition.id().id();
+            roleMap.put(partitionId, role);
+
+            if (role == Role.LEADER) {
+              if (partitionId == expectedThirdNodeLeadingPartition) {
+                raftPartition.stepDown();
+              } else {
+                latch.countDown();
+              }
+            }
+          });
+        });
+
+    // then
+    CompletableFuture.allOf(nodeOneFuture, nodeTwoFuture, nodeThreeFuture).join();
+    latch.await(15, TimeUnit.SECONDS);
+
+    // expect normal leaders are not the leaders this time
+    assertEquals(Role.FOLLOWER, nodeRoles.get(0).get(1));
+    assertEquals(Role.FOLLOWER, nodeRoles.get(1).get(2));
+    assertEquals(Role.FOLLOWER, nodeRoles.get(2).get(3));
+
+    final List<Role> leaderRoles = nodeRoles.stream().flatMap(map -> map.values().stream())
+        .filter(r -> r == Role.LEADER)
+        .collect(Collectors.toList());
+
+    final List<Role> followerRoles = nodeRoles.stream().flatMap(map -> map.values().stream())
+        .filter(r -> r == Role.FOLLOWER)
+        .collect(Collectors.toList());
+
+    assertEquals(3, leaderRoles.size());
+    assertEquals(6, followerRoles.size());
+  }
+
+  @Test
+  public void testAtomixBootstrapPartitions() throws Exception {
+    // given
+    // Partitions \ Nodes
+    //      \   0  1  2
+    //    0     L  F  F
+    //    1     F  L  F
+    //    2     F  F  L
+    final CountDownLatch latch = new CountDownLatch(3);
+    final List<Map<Integer, Role>> nodeRoles = new CopyOnWriteArrayList<>();
+    nodeRoles.add(new ConcurrentHashMap<>());
+    nodeRoles.add(new ConcurrentHashMap<>());
+    nodeRoles.add(new ConcurrentHashMap<>());
+
+    final List<Integer> members = Arrays.asList(1, 2, 3);
+
+    final int firstNodeId = 1;
+    final CompletableFuture<Atomix> nodeOneFuture = startAtomixAndCollectNodeRoles(firstNodeId,
+        members,
+        nodeRoles,
+        latch);
+
+    final int secondNodeId = 2;
+    final CompletableFuture<Atomix> nodeTwoFuture = startAtomixAndCollectNodeRoles(secondNodeId,
+        members,
+        nodeRoles,
+        latch);
+
+    final int thirdNodeId = 3;
+    final CompletableFuture<Atomix> nodeThreeFuture = startAtomixAndCollectNodeRoles(thirdNodeId,
+        members,
+        nodeRoles,
+        latch);
+
+    // then
+    CompletableFuture.allOf(nodeOneFuture, nodeTwoFuture, nodeThreeFuture).join();
+    latch.await(15, TimeUnit.SECONDS);
+
+    final Map<Integer, RaftServer.Role> expectedNodeOneRoles = new HashMap<>();
+    expectedNodeOneRoles.put(1, Role.LEADER);
+    expectedNodeOneRoles.put(2, Role.FOLLOWER);
+    expectedNodeOneRoles.put(3, Role.FOLLOWER);
+    assertEquals(expectedNodeOneRoles, nodeRoles.get(0));
+
+    final Map<Integer, RaftServer.Role> expectedNodeTwoRoles = new HashMap<>();
+    expectedNodeTwoRoles.put(1, Role.FOLLOWER);
+    expectedNodeTwoRoles.put(2, Role.LEADER);
+    expectedNodeTwoRoles.put(3, Role.FOLLOWER);
+    assertEquals(expectedNodeTwoRoles, nodeRoles.get(1));
+
+    final Map<Integer, RaftServer.Role> expectedNodeThreeRoles = new HashMap<>();
+    expectedNodeThreeRoles.put(1, Role.FOLLOWER);
+    expectedNodeThreeRoles.put(2, Role.FOLLOWER);
+    expectedNodeThreeRoles.put(3, Role.LEADER);
+    assertEquals(expectedNodeThreeRoles, nodeRoles.get(2));
+  }
+
+  @Test
+  public void testAtomixBootstrapPartitionsAndRestartingNode() throws Exception {
+    // given
+    // Partitions \ Nodes
+    //      \   0  1  2
+    //    0     L  F  F
+    //    1     F  L  F
+    //    2     F  F  L
+    final CountDownLatch latch = new CountDownLatch(3);
+    final List<Map<Integer, RaftServer.Role>> nodeRoles = new ArrayList<>();
+    nodeRoles.add(new HashMap<>());
+    nodeRoles.add(new HashMap<>());
+    nodeRoles.add(new HashMap<>());
+
+    final List<Integer> members = Arrays.asList(1, 2, 3);
+
+    final int firstNodeId = 1;
+    final CompletableFuture<Atomix> nodeOneFuture = startAtomixAndCollectNodeRoles(firstNodeId,
+        members,
+        nodeRoles, latch);
+
+    final int secondNodeId = 2;
+    final CompletableFuture<Atomix> nodeTwoFuture = startAtomixAndCollectNodeRoles(secondNodeId,
+        members,
+        nodeRoles,
+        latch);
+
+    final int thirdNodeId = 3;
+    final CompletableFuture<Atomix> nodeThreeFuture = startAtomixAndCollectNodeRoles(thirdNodeId,
+        members,
+        nodeRoles,
+        latch);
+
+    // then
+    CompletableFuture.allOf(nodeOneFuture, nodeTwoFuture, nodeThreeFuture).join();
+    latch.await(15_000, TimeUnit.MILLISECONDS);
+
+    // when
+    final Atomix atomix = nodeTwoFuture.get();
+    atomix.stop().join();
+    nodeRoles.get(1).clear();
+    final CountDownLatch newLatch = new CountDownLatch(1);
+    final CompletableFuture<Atomix> nodeTwoSecondFuture = startAtomixAndCollectNodeRoles(
+        secondNodeId,
+        members, nodeRoles, newLatch);
+
+    nodeTwoSecondFuture.join();
+    newLatch.await(5_000, TimeUnit.MILLISECONDS);
+
+    // then
+    final long nodeOneLeaderCount = nodeRoles.get(0).values().stream().filter(r -> r == Role.LEADER)
+        .count();
+    final long nodeTwoLeaderCount = nodeRoles.get(1).values().stream().filter(r -> r == Role.LEADER)
+        .count();
+    final long nodeThreeLeaderCount = nodeRoles.get(2).values().stream()
+        .filter(r -> r == Role.LEADER).count();
+
+    assertTrue(nodeOneLeaderCount == 2 || nodeThreeLeaderCount == 2);
+    assertEquals(0, nodeTwoLeaderCount);
+
+    final Map<Integer, RaftServer.Role> expectedNodeTwoRoles = new HashMap<>();
+    expectedNodeTwoRoles.put(1, Role.FOLLOWER);
+    expectedNodeTwoRoles.put(2, Role.FOLLOWER);
+    expectedNodeTwoRoles.put(3, Role.FOLLOWER);
+    assertEquals(expectedNodeTwoRoles, nodeRoles.get(1));
+  }
+
+  private CompletableFuture<Atomix> startAtomixAndCollectNodeRoles(int nodeId,
+      List<Integer> members,
+      List<Map<Integer, Role>> nodeRoles, CountDownLatch latch) {
+    return startAtomixWithPartitionConsumer(nodeId, 3, members,
+        partition -> {
+          final Map<Integer, RaftServer.Role> roleMap = nodeRoles.get(nodeId - 1);
+          final RaftPartition raftPartition = (RaftPartition) partition;
+          raftPartition.addRoleChangeListener((role) -> {
+            roleMap.put(partition.id().id(), role);
+            if (roleMap.size() >= 3) {
+              latch.countDown();
+            }
+          });
+        });
+  }
+
+  private CompletableFuture<Atomix> startSingleNodeSinglePartitionWithPartitionConsumer(
+      final Consumer<? super Partition> partitionConsumer) {
+    return startAtomixSinglePartitionWithPartitionConsumer(1, Collections.singletonList(1),
+        partitionConsumer);
+  }
+
+  private CompletableFuture<Atomix> startAtomixSinglePartitionWithPartitionConsumer(
+      final int nodeId,
+      final List<Integer> nodeIds,
+      final Consumer<? super Partition> partitionConsumer) {
+
+    return startAtomixWithPartitionConsumer(nodeId, 1, nodeIds, partitionConsumer);
+  }
+
+  private CompletableFuture<Atomix> startAtomixWithPartitionConsumer(
+      final int nodeId,
+      final int partitionCount,
+      final List<Integer> nodeIds,
+      final Consumer<? super Partition> partitionConsumer) {
+
+    final List<String> memberIds = nodeIds.stream().map(Object::toString)
+        .collect(Collectors.toList());
+
+    return startAtomix(nodeId, nodeIds,
+        builder -> {
+          final RaftPartitionGroup partitionGroup = RaftPartitionGroup.builder("system")
+              .withNumPartitions(partitionCount)
+              .withPartitionSize(memberIds.size())
+              .withMembers(memberIds)
+              .withDataDirectory(new File(new File(DATA_DIR, "log"), "" + nodeId))
+              .build();
+
+          final Atomix atomix = builder.withManagementGroup(partitionGroup).build();
+
+          final DefaultPartitionService partitionService = (DefaultPartitionService) atomix
+              .getPartitionService();
+          final RaftPartitionGroup raftPartitionGroup = (RaftPartitionGroup) partitionService
+              .getSystemPartitionGroup();
+
+          // when
+          raftPartitionGroup.getPartitions().forEach(partitionConsumer);
+          return atomix;
+        });
+  }
+
+  private CompletableFuture<Atomix> startAtomix(int id, List<Integer> persistentIds,
+      Function<AtomixBuilder, Atomix> builderFunction) {
+    final Atomix atomix = atomixRule.createAtomix(id, persistentIds, builderFunction);
+    instances.add(atomix);
+    return atomix.start().thenApply(v -> atomix);
+  }
+
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -515,6 +515,11 @@ public interface RaftServer {
   boolean isRunning();
 
   /**
+   * Steps down from the current leadership, which means tries to transition directly to follower.
+   */
+  void stepDown();
+
+  /**
    * Raft server state types.
    *
    * <p>States represent the context of the server's internal state machine. Throughout the lifetime

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -517,7 +517,7 @@ public interface RaftServer {
   /**
    * Steps down from the current leadership, which means tries to transition directly to follower.
    */
-  void stepDown();
+  CompletableFuture<Void> stepDown();
 
   /**
    * Raft server state types.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -216,6 +216,11 @@ public class DefaultRaftServer implements RaftServer {
     return started;
   }
 
+  @Override
+  public void stepDown() {
+    context.getThreadContext().execute(() -> context.transition(Role.FOLLOWER));
+  }
+
   /** Starts the server. */
   private CompletableFuture<RaftServer> start(Supplier<CompletableFuture<Void>> joiner) {
     if (started) {

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -217,8 +217,16 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public void stepDown() {
-    context.getThreadContext().execute(() -> context.transition(Role.FOLLOWER));
+  public CompletableFuture<Void> stepDown() {
+    final CompletableFuture<Void> future = new CompletableFuture<>();
+    context
+        .getThreadContext()
+        .execute(
+            () -> {
+              context.transition(Role.FOLLOWER);
+              future.complete(null);
+            });
+    return future;
   }
 
   /** Starts the server. */

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -538,11 +538,18 @@ public class RaftContext implements AutoCloseable {
     try {
       this.role = createRole(role);
       this.role.start().get();
+
     } catch (InterruptedException | ExecutionException e) {
       throw new IllegalStateException("failed to initialize Raft state", e);
     }
 
-    roleChangeListeners.forEach(l -> l.accept(this.role.role()));
+    if (this.role.role() == role) {
+      try {
+        roleChangeListeners.forEach(l -> l.accept(this.role.role()));
+      } catch (Exception exception) {
+        log.error("Unexpected error on calling role change listeners.", exception);
+      }
+    }
   }
 
   /** Checks that the current thread is the state context thread. */

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -257,7 +257,7 @@ public class RaftPartition implements Partition {
     return server;
   }
 
-  public void stepDown() {
-    server.stepDown();
+  public CompletableFuture<Void> stepDown() {
+    return server.stepDown();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -256,4 +256,8 @@ public class RaftPartition implements Partition {
   public RaftPartitionServer getServer() {
     return server;
   }
+
+  public void stepDown() {
+    server.stepDown();
+  }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -295,7 +295,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
         partition.name(), Serializer.using(RaftNamespaces.RAFT_PROTOCOL), clusterCommunicator);
   }
 
-  public void stepDown() {
-    server.stepDown();
+  public CompletableFuture<Void> stepDown() {
+    return server.stepDown();
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -294,4 +294,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return new RaftServerCommunicator(
         partition.name(), Serializer.using(RaftNamespaces.RAFT_PROTOCOL), clusterCommunicator);
   }
+
+  public void stepDown() {
+    server.stepDown();
+  }
 }


### PR DESCRIPTION
Adds new functionality on the RaftPartition,
which can be used in the RaftRoleChangeListener to step down.

This is useful for zeebe in order to step down when an error occurred
during the partition bootstrap phase.

Furthermore I added some more tests and added an AtomixRule, which can be used instead of extending this AbstractAtomixTest class.