### PR TITLE
chore(raft): include term in role change listeners

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftRoleChangeListener.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftRoleChangeListener.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2016-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.protocols.raft;
+
+import io.atomix.protocols.raft.RaftServer.Role;
+
+public interface RaftRoleChangeListener {
+  void onNewRole(Role newRole, long newTerm);
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -45,7 +45,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
@@ -231,16 +230,16 @@ public interface RaftServer {
   /**
    * Adds a role change listener.
    *
-   * @param listener The role change listener to add.
+   * @param listener The role change listener that consumes the role and the raft term.
    */
-  void addRoleChangeListener(Consumer<Role> listener);
+  void addRoleChangeListener(RaftRoleChangeListener listener);
 
   /**
    * Removes a role change listener.
    *
    * @param listener The role change listener to remove.
    */
-  void removeRoleChangeListener(Consumer<Role> listener);
+  void removeRoleChangeListener(RaftRoleChangeListener listener);
 
   /**
    * Bootstraps a single-node cluster.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -21,6 +21,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import io.atomix.cluster.MemberId;
 import io.atomix.primitive.impl.ClasspathScanningPrimitiveTypeRegistry;
 import io.atomix.primitive.service.PrimitiveService;
+import io.atomix.protocols.raft.RaftRoleChangeListener;
 import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.cluster.RaftCluster;
 import io.atomix.protocols.raft.storage.RaftStorage;
@@ -31,7 +32,6 @@ import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import java.util.Collection;
 import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import org.slf4j.Logger;
 
@@ -74,12 +74,12 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
-  public void addRoleChangeListener(Consumer<Role> listener) {
+  public void addRoleChangeListener(RaftRoleChangeListener listener) {
     context.addRoleChangeListener(listener);
   }
 
   @Override
-  public void removeRoleChangeListener(Consumer<Role> listener) {
+  public void removeRoleChangeListener(RaftRoleChangeListener listener) {
     context.removeRoleChangeListener(listener);
   }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -23,6 +23,7 @@ import io.atomix.cluster.messaging.ClusterCommunicationService;
 import io.atomix.primitive.PrimitiveTypeRegistry;
 import io.atomix.primitive.partition.Partition;
 import io.atomix.protocols.raft.RaftCommitListener;
+import io.atomix.protocols.raft.RaftRoleChangeListener;
 import io.atomix.protocols.raft.RaftServer;
 import io.atomix.protocols.raft.RaftServer.Role;
 import io.atomix.protocols.raft.partition.RaftCompactionConfig;
@@ -51,7 +52,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.function.Consumer;
 import org.slf4j.Logger;
 
 /** {@link Partition} server. */
@@ -66,7 +66,8 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
   private final ClusterCommunicationService clusterCommunicator;
   private final PrimitiveTypeRegistry primitiveTypes;
   private final ThreadContextFactory threadContextFactory;
-  private final Set<Consumer<Role>> deferredRoleChangeListeners = new CopyOnWriteArraySet<>();
+  private final Set<RaftRoleChangeListener> deferredRoleChangeListeners =
+      new CopyOnWriteArraySet<>();
   private final Set<RaftCommitListener> commitListeners = new CopyOnWriteArraySet<>();
 
   private RaftServer server;
@@ -186,7 +187,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     return server.getContext().getLog().openReader(index, mode);
   }
 
-  public void addRoleChangeListener(final Consumer<Role> listener) {
+  public void addRoleChangeListener(final RaftRoleChangeListener listener) {
     if (server == null) {
       deferredRoleChangeListeners.add(listener);
     } else {
@@ -194,7 +195,7 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     }
   }
 
-  public void removeRoleChangeListener(final Consumer<Role> listener) {
+  public void removeRoleChangeListener(final RaftRoleChangeListener listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -401,7 +401,7 @@ public class RaftTest extends ConcurrentTestCase {
     await(15000, 100);
     final RaftServer joiner = createServer(nextNodeId());
     joiner.addRoleChangeListener(
-        s -> {
+        (s, t) -> {
           if (s == role) {
             resume();
           }


### PR DESCRIPTION
* Add new RaftRoleChangeListener interface which accepts both role and term

Related to https://github.com/zeebe-io/zeebe/issues/3697