### PR TITLE
chore(raft): fixes race condition when resetting heartbeat timer

### DIFF
--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
@@ -317,7 +317,7 @@ public class DefaultServiceExecutor implements ServiceExecutor {
 
     @Override
     public synchronized boolean isDone() {
-      return scheduledTasks.contains(this);
+      return !scheduledTasks.contains(this);
     }
   }
 }

--- a/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
+++ b/primitive/src/main/java/io/atomix/primitive/service/impl/DefaultServiceExecutor.java
@@ -314,5 +314,10 @@ public class DefaultServiceExecutor implements ServiceExecutor {
     public synchronized void cancel() {
       scheduledTasks.remove(this);
     }
+
+    @Override
+    public synchronized boolean isDone() {
+      return scheduledTasks.contains(this);
+    }
   }
 }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -727,15 +727,6 @@ public class RaftContext implements AutoCloseable {
   }
 
   public ThreadContext getHeartbeatThread() {
-    // we should avoid to use to many different threads
-    // it makes sense to accept incoming requests (like heartbeats, appends etc) by one thread
-    // then we do not need to synchronize the resource access
-    // for sending we need multiple threads such that we are able to send heartbeats in time
-
-    if (!(role instanceof LeaderRole)) {
-      throw new IllegalStateException("The heartbeat thread should only used by the leader!");
-    }
-
     return heartBeatThread;
   }
 

--- a/utils/src/main/java/io/atomix/utils/concurrent/ScheduledFutureImpl.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ScheduledFutureImpl.java
@@ -13,26 +13,25 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.atomix.utils.concurrent;
 
-/**
- * Scheduled task.
- *
- * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
- */
-public interface Scheduled {
+import java.util.concurrent.Future;
 
-  /**
-   * Cancels the scheduled task.
-   */
-  void cancel();
+/** Simple wrapper class that delegates to a non-interruptible future */
+final class ScheduledFutureImpl<T> implements Scheduled {
+  private final Future<T> future;
 
-  /**
-   * Returns whether this scheduled entity was already completed or not, regardless of if it was
-   * cancelled or successfully executed.
-   *
-   * @return true if already completed, false otherwise
-   */
-  boolean isDone();
+  ScheduledFutureImpl(final Future<T> future) {
+    this.future = future;
+  }
+
+  @Override
+  public void cancel() {
+    future.cancel(false);
+  }
+
+  @Override
+  public boolean isDone() {
+    return future.isDone();
+  }
 }

--- a/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/SingleThreadContext.java
@@ -119,13 +119,13 @@ public class SingleThreadContext extends AbstractThreadContext {
   @Override
   public Scheduled schedule(Duration delay, Runnable runnable) {
     ScheduledFuture<?> future = executor.schedule(runnable, delay.toMillis(), TimeUnit.MILLISECONDS);
-    return () -> future.cancel(false);
+    return new ScheduledFutureImpl<>(future);
   }
 
   @Override
   public Scheduled schedule(Duration delay, Duration interval, Runnable runnable) {
     ScheduledFuture<?> future = executor.scheduleAtFixedRate(runnable, delay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
-    return () -> future.cancel(false);
+    return new ScheduledFutureImpl<>(future);
   }
 
   @Override

--- a/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
+++ b/utils/src/main/java/io/atomix/utils/concurrent/ThreadPoolContext.java
@@ -95,13 +95,13 @@ public class ThreadPoolContext extends AbstractThreadContext {
   @Override
   public Scheduled schedule(Duration delay, Runnable runnable) {
     ScheduledFuture<?> future = parent.schedule(() -> executor.execute(runnable), delay.toMillis(), TimeUnit.MILLISECONDS);
-    return () -> future.cancel(false);
+    return new ScheduledFutureImpl<>(future);
   }
 
   @Override
   public Scheduled schedule(Duration delay, Duration interval, Runnable runnable) {
     ScheduledFuture<?> future = parent.scheduleAtFixedRate(() -> executor.execute(runnable), delay.toMillis(), interval.toMillis(), TimeUnit.MILLISECONDS);
-    return () -> future.cancel(false);
+    return new ScheduledFutureImpl<>(future);
   }
 
   @Override


### PR DESCRIPTION
**Description:**

- serializes access to `heartbeatTimer` to ensure we only set it in a single thread
- adds check to ensure we always cancel a timer before rescheduling it

**Related issues:**

closes #139, [zeebe-io/zeebe#3705](https://github.com/zeebe-io/zeebe/issues/3705)