### PR TITLE
chore(utils): use custom serializer to avoid using FieldSerializer on private APIs

### DIFF
--- a/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespace.java
@@ -358,11 +358,9 @@ public final class Namespace implements KryoFactory, KryoPool {
    * @param buffer to write to
    */
   public void serialize(final Object obj, final ByteBuffer buffer) {
-    ByteBufferOutput out = new ByteBufferOutput(buffer);
     Kryo kryo = borrow();
-    try {
+    try (ByteBufferOutput out = new ByteBufferOutput(buffer)) {
       kryo.writeClassAndObject(out, obj);
-      out.flush();
     } finally {
       release(kryo);
     }
@@ -386,11 +384,9 @@ public final class Namespace implements KryoFactory, KryoPool {
    * @param bufferSize size of the buffer in front of the stream
    */
   public void serialize(final Object obj, final OutputStream stream, final int bufferSize) {
-    ByteBufferOutput out = new ByteBufferOutput(stream, bufferSize);
     Kryo kryo = borrow();
-    try {
+    try (ByteBufferOutput out = new ByteBufferOutput(stream, bufferSize)) {
       kryo.writeClassAndObject(out, obj);
-      out.flush();
     } finally {
       release(kryo);
     }
@@ -422,9 +418,8 @@ public final class Namespace implements KryoFactory, KryoPool {
    * @return deserialized Object
    */
   public <T> T deserialize(final ByteBuffer buffer) {
-    ByteBufferInput in = new ByteBufferInput(buffer);
     Kryo kryo = borrow();
-    try {
+    try (ByteBufferInput in = new ByteBufferInput(buffer)) {
       @SuppressWarnings("unchecked")
       T obj = (T) kryo.readClassAndObject(in);
       return obj;
@@ -453,9 +448,8 @@ public final class Namespace implements KryoFactory, KryoPool {
    * @return deserialized Object
    */
   public <T> T deserialize(final InputStream stream, final int bufferSize) {
-    ByteBufferInput in = new ByteBufferInput(stream, bufferSize);
     Kryo kryo = borrow();
-    try {
+    try (ByteBufferInput in = new ByteBufferInput(stream, bufferSize)) {
       @SuppressWarnings("unchecked")
       T obj = (T) kryo.readClassAndObject(in);
       return obj;
@@ -580,7 +574,7 @@ public final class Namespace implements KryoFactory, KryoPool {
 
   @Override
   public String toString() {
-    if (friendlyName != NO_NAME) {
+    if (!friendlyName.equals(NO_NAME)) {
       return MoreObjects.toStringHelper(getClass())
           .omitNullValues()
           .add("friendlyName", friendlyName)

--- a/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/Namespaces.java
@@ -24,6 +24,9 @@ import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
 import io.atomix.utils.Version;
 import io.atomix.utils.serializer.serializers.ArraysAsListSerializer;
+import io.atomix.utils.serializer.serializers.AtomicBooleanSerializer;
+import io.atomix.utils.serializer.serializers.AtomicIntegerSerializer;
+import io.atomix.utils.serializer.serializers.AtomicLongSerializer;
 import io.atomix.utils.serializer.serializers.ByteBufferSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableListSerializer;
 import io.atomix.utils.serializer.serializers.ImmutableMapSerializer;
@@ -54,9 +57,9 @@ public final class Namespaces {
   public static final Namespace BASIC = Namespace.builder()
       .nextId(Namespace.FLOATING_ID)
       .register(byte[].class)
-      .register(AtomicBoolean.class)
-      .register(AtomicInteger.class)
-      .register(AtomicLong.class)
+      .register(new AtomicBooleanSerializer(), AtomicBoolean.class)
+      .register(new AtomicIntegerSerializer(), AtomicInteger.class)
+      .register(new AtomicLongSerializer(), AtomicLong.class)
       .register(new ImmutableListSerializer(),
           ImmutableList.class,
           ImmutableList.of(1).getClass(),

--- a/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicBooleanSerializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicBooleanSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class AtomicBooleanSerializer extends Serializer<AtomicBoolean> {
+
+  @Override
+  public void write(final Kryo kryo, final Output output, final AtomicBoolean object) {
+    output.writeBoolean(object.get());
+  }
+
+  @Override
+  public AtomicBoolean read(final Kryo kryo, final Input input, final Class<AtomicBoolean> type) {
+    return new AtomicBoolean(input.readBoolean());
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicIntegerSerializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicIntegerSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class AtomicIntegerSerializer extends Serializer<AtomicInteger> {
+
+  @Override
+  public void write(final Kryo kryo, final Output output, final AtomicInteger object) {
+    output.writeInt(object.get());
+  }
+
+  @Override
+  public AtomicInteger read(final Kryo kryo, final Input input, final Class<AtomicInteger> type) {
+    return new AtomicInteger(input.readInt());
+  }
+}

--- a/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicLongSerializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/serializers/AtomicLongSerializer.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.Serializer;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class AtomicLongSerializer extends Serializer<AtomicLong> {
+
+  @Override
+  public void write(final Kryo kryo, final Output output, final AtomicLong object) {
+    output.writeLong(object.get());
+  }
+
+  @Override
+  public AtomicLong read(final Kryo kryo, final Input input, final Class<AtomicLong> type) {
+    return new AtomicLong(input.readLong());
+  }
+}

--- a/utils/src/test/java/io/atomix/utils/serializer/serializers/AtomicSerializersTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/serializers/AtomicSerializersTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014-present Open Networking Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.atomix.utils.serializer.serializers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.esotericsoftware.kryo.Kryo;
+import com.esotericsoftware.kryo.io.ByteBufferInput;
+import com.esotericsoftware.kryo.io.ByteBufferOutput;
+import com.esotericsoftware.kryo.io.Input;
+import com.esotericsoftware.kryo.io.Output;
+import java.nio.ByteBuffer;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AtomicSerializersTest {
+  private static final int CAPACITY = 1024;
+  private static final Kryo KRYO = new Kryo();
+
+  private Output output;
+  private Input input;
+
+  @BeforeClass
+  public static void register() {
+    KRYO.register(AtomicLong.class, new AtomicLongSerializer());
+    KRYO.register(AtomicInteger.class, new AtomicIntegerSerializer());
+    KRYO.register(AtomicBoolean.class, new AtomicBooleanSerializer());
+  }
+
+  @Before
+  public void setUp() {
+    final ByteBuffer buffer = ByteBuffer.allocate(CAPACITY);
+
+    output = new ByteBufferOutput(buffer);
+    input = new ByteBufferInput(buffer);
+  }
+
+  @After
+  public void tearDown() {
+    output.close();
+    input.close();
+  }
+
+  @Test
+  public void shouldSerializeDeserializeLong() {
+    // given
+    final AtomicLong original = new AtomicLong(1);
+
+    // when
+    original.set(32L);
+    KRYO.writeObject(output, original);
+    final AtomicLong deserialized = KRYO.readObject(input, AtomicLong.class);
+
+    // then
+    assertEquals(32L, deserialized.get());
+  }
+
+  @Test
+  public void shouldSerializeDeserializeInteger() {
+    // given
+    final AtomicInteger original = new AtomicInteger(1);
+
+    // when
+    original.set(1000);
+    KRYO.writeObject(output, original);
+    final AtomicInteger deserialized = KRYO.readObject(input, AtomicInteger.class);
+
+    // then
+    assertEquals(1000, deserialized.get());
+  }
+
+  @Test
+  public void shouldSerializeDeserializeBoolean() {
+    // given
+    final AtomicBoolean original = new AtomicBoolean(false);
+
+    // when
+    original.set(true);
+    KRYO.writeObject(output, original);
+    final AtomicBoolean deserialized = KRYO.readObject(input, AtomicBoolean.class);
+
+    // then
+    assertTrue(deserialized.get());
+  }
+}


### PR DESCRIPTION
**Description:**

- adds new serializers for `AtomicLong`, `AtomicInteger`, and `AtomicBoolean`, to avoid using reflection in order to serialize them (producing illegal access warnings)

**Related issues:**

related to [zeebe-io/zeebe#3711](https://github.com/zeebe-io/zeebe/issues/3711)