### PR TITLE
chore(storage): introduce JournalIndex injection

### DIFF
--- a/protocols/log/src/main/java/io/atomix/protocols/log/DistributedLogServer.java
+++ b/protocols/log/src/main/java/io/atomix/protocols/log/DistributedLogServer.java
@@ -119,7 +119,6 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
     private static final long DEFAULT_MAX_LOG_SIZE = 1024 * 1024 * 1024;
     private static final Duration DEFAULT_MAX_LOG_AGE = null;
-    private static final int DEFAULT_INDEX_DENSITY = 200;
 
     protected String serverName = DEFAULT_SERVER_NAME;
     protected ClusterMembershipService membershipService;
@@ -136,7 +135,6 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     protected File directory = new File(DEFAULT_DIRECTORY);
     protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
-    protected int indexDensity = DEFAULT_INDEX_DENSITY;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     protected long maxLogSize = DEFAULT_MAX_LOG_SIZE;
     protected Duration maxLogAge = DEFAULT_MAX_LOG_AGE;
@@ -401,7 +399,6 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
               .build())
           .withMaxSegmentSize(maxSegmentSize)
           .withMaxEntrySize(maxEntrySize)
-          .withIndexDensity(indexDensity)
           .withFlushOnCommit(flushOnCommit)
           .build();
 

--- a/protocols/log/src/main/java/io/atomix/protocols/log/DistributedLogServer.java
+++ b/protocols/log/src/main/java/io/atomix/protocols/log/DistributedLogServer.java
@@ -15,6 +15,9 @@
  */
 package io.atomix.protocols.log;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.atomix.cluster.ClusterMembershipService;
 import io.atomix.primitive.Replication;
 import io.atomix.primitive.partition.MemberGroupProvider;
@@ -32,14 +35,10 @@ import io.atomix.utils.logging.ContextualLoggerFactory;
 import io.atomix.utils.logging.LoggerContext;
 import io.atomix.utils.serializer.Namespace;
 import io.atomix.utils.serializer.Namespaces;
-import org.slf4j.Logger;
-
 import java.io.File;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
+import org.slf4j.Logger;
 
 /**
  * Log server.
@@ -110,6 +109,7 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
    * Log server builder
    */
   public static class Builder implements io.atomix.utils.Builder<DistributedLogServer> {
+
     private static final String DEFAULT_SERVER_NAME = "atomix";
     private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
     private static final int DEFAULT_REPLICATION_FACTOR = 2;
@@ -119,7 +119,7 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
     private static final long DEFAULT_MAX_LOG_SIZE = 1024 * 1024 * 1024;
     private static final Duration DEFAULT_MAX_LOG_AGE = null;
-    private static final double DEFAULT_INDEX_DENSITY = .005;
+    private static final int DEFAULT_INDEX_DENSITY = 200;
 
     protected String serverName = DEFAULT_SERVER_NAME;
     protected ClusterMembershipService membershipService;
@@ -127,7 +127,8 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     protected PrimaryElection primaryElection;
     protected MemberGroupProvider memberGroupProvider;
     protected ThreadModel threadModel = ThreadModel.SHARED_THREAD_POOL;
-    protected int threadPoolSize = Math.max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
+    protected int threadPoolSize = Math
+        .max(Math.min(Runtime.getRuntime().availableProcessors() * 2, 16), 4);
     protected ThreadContextFactory threadContextFactory;
     protected int replicationFactor = DEFAULT_REPLICATION_FACTOR;
     protected Replication replicationStrategy = DEFAULT_REPLICATION_STRATEGY;
@@ -135,7 +136,7 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     protected File directory = new File(DEFAULT_DIRECTORY);
     protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
-    protected double indexDensity = DEFAULT_INDEX_DENSITY;
+    protected int indexDensity = DEFAULT_INDEX_DENSITY;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
     protected long maxLogSize = DEFAULT_MAX_LOG_SIZE;
     protected Duration maxLogAge = DEFAULT_MAX_LOG_AGE;
@@ -229,7 +230,8 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
      * @throws NullPointerException if the factory is null
      */
     public Builder withThreadContextFactory(ThreadContextFactory threadContextFactory) {
-      this.threadContextFactory = checkNotNull(threadContextFactory, "threadContextFactory cannot be null");
+      this.threadContextFactory = checkNotNull(threadContextFactory,
+          "threadContextFactory cannot be null");
       return this;
     }
 
@@ -254,7 +256,8 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
      * @throws NullPointerException if the replication strategy is null
      */
     public Builder withReplicationStrategy(Replication replicationStrategy) {
-      this.replicationStrategy = checkNotNull(replicationStrategy, "replicationStrategy cannot be null");
+      this.replicationStrategy = checkNotNull(replicationStrategy,
+          "replicationStrategy cannot be null");
       return this;
     }
 
@@ -301,9 +304,10 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     /**
      * Sets the maximum segment size in bytes, returning the builder for method chaining.
      * <p>
-     * The maximum segment size dictates when logs should roll over to new segments. As entries are written to a segment
-     * of the log, once the size of the segment surpasses the configured maximum segment size, the log will create a new
-     * segment and append new entries to that segment.
+     * The maximum segment size dictates when logs should roll over to new segments. As entries are
+     * written to a segment of the log, once the size of the segment surpasses the configured
+     * maximum segment size, the log will create a new segment and append new entries to that
+     * segment.
      * <p>
      * By default, the maximum segment size is {@code 1024 * 1024 * 32}.
      *
@@ -330,42 +334,14 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
     }
 
     /**
-     * Sets the journal index density.
+     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
+     * builder for method chaining.
      * <p>
-     * The index density is the frequency at which the position of entries written to the journal will be recorded in an
-     * in-memory index for faster seeking.
+     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each
+     * time an entry is committed in a given segment.
      *
-     * @param indexDensity the index density
-     * @return the journal builder
-     * @throws IllegalArgumentException if the density is not between 0 and 1
-     */
-    public Builder withIndexDensity(double indexDensity) {
-      checkArgument(indexDensity > 0 && indexDensity < 1, "index density must be between 0 and 1");
-      this.indexDensity = indexDensity;
-      return this;
-    }
-
-    /**
-     * Enables flushing buffers to disk when entries are committed to a segment, returning the builder for method
-     * chaining.
-     * <p>
-     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time an entry is
-     * committed in a given segment.
-     *
-     * @return The storage builder.
-     */
-    public Builder withFlushOnCommit() {
-      return withFlushOnCommit(true);
-    }
-
-    /**
-     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the builder for method
-     * chaining.
-     * <p>
-     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time an entry is
-     * committed in a given segment.
-     *
-     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a segment.
+     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a
+     * segment.
      * @return The storage builder.
      */
     public Builder withFlushOnCommit(boolean flushOnCommit) {
@@ -397,15 +373,17 @@ public class DistributedLogServer implements Managed<DistributedLogServer> {
 
     @Override
     public DistributedLogServer build() {
-      Logger log = ContextualLoggerFactory.getLogger(DistributedLogServer.class, LoggerContext.builder(DistributedLogServer.class)
-          .addValue(serverName)
-          .build());
+      Logger log = ContextualLoggerFactory
+          .getLogger(DistributedLogServer.class, LoggerContext.builder(DistributedLogServer.class)
+              .addValue(serverName)
+              .build());
 
       // If a ThreadContextFactory was not provided, create one and ensure it's closed when the server is stopped.
       boolean closeOnStop;
       ThreadContextFactory threadContextFactory;
       if (this.threadContextFactory == null) {
-        threadContextFactory = threadModel.factory("backup-server-" + serverName + "-%d", threadPoolSize, log);
+        threadContextFactory = threadModel
+            .factory("backup-server-" + serverName + "-%d", threadPoolSize, log);
         closeOnStop = true;
       } else {
         threadContextFactory = this.threadContextFactory;

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -36,6 +36,8 @@ import io.atomix.protocols.raft.storage.snapshot.impl.DefaultSnapshotStore;
 import io.atomix.protocols.raft.utils.LoadMonitor;
 import io.atomix.protocols.raft.utils.LoadMonitorFactory;
 import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.utils.Builder;
 import io.atomix.utils.concurrent.ThreadContextFactory;
 import io.atomix.utils.concurrent.ThreadModel;
 import java.net.InetAddress;
@@ -653,6 +655,7 @@ public interface RaftServer {
     protected ThreadContextFactory threadContextFactory;
     protected RaftStateMachineFactory stateMachineFactory = RaftServiceManager::new;
     protected LoadMonitorFactory loadMonitorFactory = LoadMonitor::new;
+    protected Supplier<JournalIndex> journalIndexFactory;
 
     protected Builder(MemberId localMemberId) {
       this.localMemberId = checkNotNull(localMemberId, "localMemberId cannot be null");
@@ -835,6 +838,11 @@ public interface RaftServer {
      */
     public Builder withLoadMonitorFactory(LoadMonitorFactory loadMonitorFactory) {
       this.loadMonitorFactory = loadMonitorFactory;
+      return this;
+    }
+
+    public Builder withJournalIndexFactory(final Supplier<JournalIndex> journalIndexFactory) {
+      this.journalIndexFactory = journalIndexFactory;
       return this;
     }
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -20,8 +20,10 @@ import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.DelegatingJournal;
 import io.atomix.storage.journal.JournalReader;
 import io.atomix.storage.journal.SegmentedJournal;
+import io.atomix.storage.journal.index.JournalIndex;
 import io.atomix.utils.serializer.Namespace;
 import java.io.File;
+import java.util.function.Supplier;
 
 /** Raft log. */
 public class RaftLog extends DelegatingJournal<RaftLogEntry> {
@@ -115,6 +117,7 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
     private final SegmentedJournal.Builder<RaftLogEntry> journalBuilder =
         SegmentedJournal.builder();
+    private Supplier<JournalIndex> journalIndexFactory;
 
     protected Builder() {}
 
@@ -236,46 +239,6 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
     }
 
     /**
-     * Sets the log index density.
-     *
-     * <p>The index density is the frequency at which the position of entries written to the journal
-     * will be recorded in an in-memory index for faster seeking.
-     *
-     * @param indexDensity the index density
-     * @return the log builder
-     * @throws IllegalArgumentException if the density is not between 0 and 1
-     */
-    public Builder withIndexDensity(double indexDensity) {
-      journalBuilder.withIndexDensity(indexDensity);
-      return this;
-    }
-
-    /**
-     * Sets the log cache size.
-     *
-     * @param cacheSize the log cache size
-     * @return the log builder
-     * @throws IllegalArgumentException if the cache size is not positive
-     */
-    public Builder withCacheSize(int cacheSize) {
-      journalBuilder.withCacheSize(cacheSize);
-      return this;
-    }
-
-    /**
-     * Enables flushing buffers to disk when entries are committed to a segment, returning the
-     * builder for method chaining.
-     *
-     * <p>When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk
-     * each time an entry is committed in a given segment.
-     *
-     * @return The storage builder.
-     */
-    public Builder withFlushOnCommit() {
-      return withFlushOnCommit(true);
-    }
-
-    /**
      * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
      * builder for method chaining.
      *
@@ -288,6 +251,11 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
      */
     public Builder withFlushOnCommit(boolean flushOnCommit) {
       journalBuilder.withFlushOnCommit(flushOnCommit);
+      return this;
+    }
+
+    public Builder withJournalIndexFactory(final Supplier<JournalIndex> journalIndexFactory) {
+      journalBuilder.withJournalIndexFactory(journalIndexFactory);
       return this;
     }
 

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/log/RaftLog.java
@@ -117,7 +117,6 @@ public class RaftLog extends DelegatingJournal<RaftLogEntry> {
 
     private final SegmentedJournal.Builder<RaftLogEntry> journalBuilder =
         SegmentedJournal.builder();
-    private Supplier<JournalIndex> journalIndexFactory;
 
     protected Builder() {}
 

--- a/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
+++ b/storage/src/main/java/io/atomix/storage/journal/SegmentedJournal.java
@@ -15,7 +15,17 @@
  */
 package io.atomix.storage.journal;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+import com.google.common.collect.Sets;
+import io.atomix.storage.StorageException;
+import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.index.JournalIndex;
+import io.atomix.storage.journal.index.SparseJournalIndex;
 import io.atomix.storage.statistics.JournalMetrics;
+import io.atomix.utils.serializer.Namespace;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -29,17 +39,9 @@ import java.util.NavigableMap;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
-
-import com.google.common.collect.Sets;
-import io.atomix.storage.StorageException;
-import io.atomix.storage.StorageLevel;
-import io.atomix.utils.serializer.Namespace;
+import java.util.function.Supplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Segmented journal.
@@ -47,6 +49,7 @@ import static com.google.common.base.Preconditions.checkState;
 public class SegmentedJournal<E> implements Journal<E> {
 
   private final JournalMetrics journalMetrics;
+  private final Supplier<JournalIndex> journalIndexFactory;
 
   /**
    * Returns a new Raft log builder.
@@ -67,7 +70,6 @@ public class SegmentedJournal<E> implements Journal<E> {
   private final int maxSegmentSize;
   private final int maxEntrySize;
   private final int maxEntriesPerSegment;
-  private final double indexDensity;
   private final boolean flushOnCommit;
   private final SegmentedJournalWriter<E> writer;
   private volatile long commitIndex;
@@ -86,8 +88,9 @@ public class SegmentedJournal<E> implements Journal<E> {
       int maxSegmentSize,
       int maxEntrySize,
       int maxEntriesPerSegment,
-      double indexDensity,
-      boolean flushOnCommit) {
+      int indexDensity,
+      boolean flushOnCommit,
+      final Supplier<JournalIndex> journalIndexFactory) {
     this.name = checkNotNull(name, "name cannot be null");
     this.storageLevel = checkNotNull(storageLevel, "storageLevel cannot be null");
     this.directory = checkNotNull(directory, "directory cannot be null");
@@ -95,9 +98,11 @@ public class SegmentedJournal<E> implements Journal<E> {
     this.maxSegmentSize = maxSegmentSize;
     this.maxEntrySize = maxEntrySize;
     this.maxEntriesPerSegment = maxEntriesPerSegment;
-    this.indexDensity = indexDensity;
     this.flushOnCommit = flushOnCommit;
     journalMetrics = new JournalMetrics(name);
+    this.journalIndexFactory =
+        journalIndexFactory == null ? () -> new SparseJournalIndex(indexDensity)
+            : journalIndexFactory;
     open();
     this.writer = openWriter();
   }
@@ -118,9 +123,9 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Returns the storage directory.
    * <p>
-   * The storage directory is the directory to which all segments write files. Segment files for multiple logs may be
-   * stored in the storage directory, and files for each log instance will be identified by the {@code prefix} provided
-   * when the log is opened.
+   * The storage directory is the directory to which all segments write files. Segment files for
+   * multiple logs may be stored in the storage directory, and files for each log instance will be
+   * identified by the {@code prefix} provided when the log is opened.
    *
    * @return The storage directory.
    */
@@ -142,7 +147,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Returns the maximum journal segment size.
    * <p>
-   * The maximum segment size dictates the maximum size any segment in a segment may consume in bytes.
+   * The maximum segment size dictates the maximum size any segment in a segment may consume in
+   * bytes.
    *
    * @return The maximum segment size in bytes.
    */
@@ -153,7 +159,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Returns the maximum journal entry size.
    * <p>
-   * The maximum entry size dictates the maximum size any entry in the segment may consume in bytes.
+   * The maximum entry size dictates the maximum size any entry in the segment may consume in
+   * bytes.
    *
    * @return the maximum entry size in bytes
    */
@@ -164,8 +171,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   /**
    * Returns the maximum number of entries per segment.
    * <p>
-   * The maximum entries per segment dictates the maximum number of entries that are allowed to be stored in any segment
-   * in a journal.
+   * The maximum entries per segment dictates the maximum number of entries that are allowed to be
+   * stored in any segment in a journal.
    *
    * @return The maximum number of entries per segment.
    * @deprecated since 3.0.2
@@ -278,7 +285,8 @@ public class SegmentedJournal<E> implements Journal<E> {
    */
   private void assertDiskSpace() {
     if (directory().getUsableSpace() < maxSegmentSize() * SEGMENT_BUFFER_FACTOR) {
-      throw new StorageException.OutOfDiskSpace("Not enough space to allocate a new journal segment");
+      throw new StorageException.OutOfDiskSpace(
+          "Not enough space to allocate a new journal segment");
     }
   }
 
@@ -436,7 +444,7 @@ public class SegmentedJournal<E> implements Journal<E> {
     try {
       raf = new RandomAccessFile(segmentFile, "rw");
       raf.setLength(descriptor.maxSegmentSize());
-      channel =  raf.getChannel();
+      channel = raf.getChannel();
     } catch (IOException e) {
       throw new StorageException(e);
     }
@@ -467,8 +475,10 @@ public class SegmentedJournal<E> implements Journal<E> {
    * @param descriptor The segment descriptor.
    * @return The segment instance.
    */
-  protected JournalSegment<E> newSegment(JournalSegmentFile segmentFile, JournalSegmentDescriptor descriptor) {
-    return new JournalSegment<>(segmentFile, descriptor, storageLevel, maxEntrySize, indexDensity, namespace);
+  protected JournalSegment<E> newSegment(JournalSegmentFile segmentFile,
+      JournalSegmentDescriptor descriptor) {
+    return new JournalSegment<>(segmentFile, descriptor, storageLevel, maxEntrySize, namespace,
+        journalIndexFactory.get());
   }
 
   /**
@@ -491,7 +501,8 @@ public class SegmentedJournal<E> implements Journal<E> {
 
   private FileChannel openChannel(File file) {
     try {
-      return FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.READ, StandardOpenOption.WRITE);
+      return FileChannel.open(file.toPath(), StandardOpenOption.CREATE, StandardOpenOption.READ,
+          StandardOpenOption.WRITE);
     } catch (IOException e) {
       throw new StorageException(e);
     }
@@ -528,7 +539,8 @@ public class SegmentedJournal<E> implements Journal<E> {
         JournalSegment<E> segment = loadSegment(descriptor.id());
 
         // Add the segment to the segments list.
-        log.debug("Found segment: {} ({})", segment.descriptor().id(), segmentFile.file().getName());
+        log.debug("Found segment: {} ({})", segment.descriptor().id(),
+            segmentFile.file().getName());
         segments.put(segment.index(), segment);
       }
     }
@@ -540,7 +552,8 @@ public class SegmentedJournal<E> implements Journal<E> {
     while (iterator.hasNext()) {
       JournalSegment<E> segment = iterator.next().getValue();
       if (previousSegment != null && previousSegment.lastIndex() != segment.index() - 1) {
-        log.warn("Journal is inconsistent. {} is not aligned with prior segment {}", segment.file().file(), previousSegment.file().file());
+        log.warn("Journal is inconsistent. {} is not aligned with prior segment {}",
+            segment.file().file(), previousSegment.file().file());
         corrupted = true;
       }
       if (corrupted) {
@@ -590,7 +603,8 @@ public class SegmentedJournal<E> implements Journal<E> {
   }
 
   /**
-   * Returns a boolean indicating whether a segment can be removed from the journal prior to the given index.
+   * Returns a boolean indicating whether a segment can be removed from the journal prior to the
+   * given index.
    *
    * @param index the index from which to remove segments
    * @return indicates whether a segment can be removed from the journal
@@ -621,11 +635,13 @@ public class SegmentedJournal<E> implements Journal<E> {
   public void compact(long index) {
     Map.Entry<Long, JournalSegment<E>> segmentEntry = segments.floorEntry(index);
     if (segmentEntry != null) {
-      SortedMap<Long, JournalSegment<E>> compactSegments = segments.headMap(segmentEntry.getValue().index());
+      SortedMap<Long, JournalSegment<E>> compactSegments = segments
+          .headMap(segmentEntry.getValue().index());
       if (!compactSegments.isEmpty()) {
         log.debug("{} - Compacting {} segment(s)", name, compactSegments.size());
         for (JournalSegment segment : compactSegments.values()) {
           log.trace("Deleting segment: {}", segment);
+          segment.compactIndex(index);
           segment.close();
           segment.delete();
         }
@@ -676,13 +692,14 @@ public class SegmentedJournal<E> implements Journal<E> {
    * Raft log builder.
    */
   public static class Builder<E> implements io.atomix.utils.Builder<SegmentedJournal<E>> {
+
     private static final boolean DEFAULT_FLUSH_ON_COMMIT = false;
     private static final String DEFAULT_NAME = "atomix";
     private static final String DEFAULT_DIRECTORY = System.getProperty("user.dir");
     private static final int DEFAULT_MAX_SEGMENT_SIZE = 1024 * 1024 * 32;
     private static final int DEFAULT_MAX_ENTRY_SIZE = 1024 * 1024;
     private static final int DEFAULT_MAX_ENTRIES_PER_SEGMENT = 1024 * 1024;
-    private static final double DEFAULT_INDEX_DENSITY = .005;
+    private static final int DEFAULT_INDEX_DENSITY = 200;
     private static final int DEFAULT_CACHE_SIZE = 1024;
 
     protected String name = DEFAULT_NAME;
@@ -692,9 +709,10 @@ public class SegmentedJournal<E> implements Journal<E> {
     protected int maxSegmentSize = DEFAULT_MAX_SEGMENT_SIZE;
     protected int maxEntrySize = DEFAULT_MAX_ENTRY_SIZE;
     protected int maxEntriesPerSegment = DEFAULT_MAX_ENTRIES_PER_SEGMENT;
-    protected double indexDensity = DEFAULT_INDEX_DENSITY;
+    protected int indexDensity = DEFAULT_INDEX_DENSITY;
     protected int cacheSize = DEFAULT_CACHE_SIZE;
     private boolean flushOnCommit = DEFAULT_FLUSH_ON_COMMIT;
+    private Supplier<JournalIndex> journalIndexFactory;
 
     protected Builder() {
     }
@@ -764,9 +782,10 @@ public class SegmentedJournal<E> implements Journal<E> {
     /**
      * Sets the maximum segment size in bytes, returning the builder for method chaining.
      * <p>
-     * The maximum segment size dictates when logs should roll over to new segments. As entries are written to a segment
-     * of the log, once the size of the segment surpasses the configured maximum segment size, the log will create a new
-     * segment and append new entries to that segment.
+     * The maximum segment size dictates when logs should roll over to new segments. As entries are
+     * written to a segment of the log, once the size of the segment surpasses the configured
+     * maximum segment size, the log will create a new segment and append new entries to that
+     * segment.
      * <p>
      * By default, the maximum segment size is {@code 1024 * 1024 * 32}.
      *
@@ -775,7 +794,8 @@ public class SegmentedJournal<E> implements Journal<E> {
      * @throws IllegalArgumentException If the {@code maxSegmentSize} is not positive
      */
     public Builder<E> withMaxSegmentSize(int maxSegmentSize) {
-      checkArgument(maxSegmentSize > JournalSegmentDescriptor.BYTES, "maxSegmentSize must be greater than " + JournalSegmentDescriptor.BYTES);
+      checkArgument(maxSegmentSize > JournalSegmentDescriptor.BYTES,
+          "maxSegmentSize must be greater than " + JournalSegmentDescriptor.BYTES);
       this.maxSegmentSize = maxSegmentSize;
       return this;
     }
@@ -794,18 +814,20 @@ public class SegmentedJournal<E> implements Journal<E> {
     }
 
     /**
-     * Sets the maximum number of allows entries per segment, returning the builder for method chaining.
+     * Sets the maximum number of allows entries per segment, returning the builder for method
+     * chaining.
      * <p>
-     * The maximum entry count dictates when logs should roll over to new segments. As entries are written to a segment
-     * of the log, if the entry count in that segment meets the configured maximum entry count, the log will create a
-     * new segment and append new entries to that segment.
+     * The maximum entry count dictates when logs should roll over to new segments. As entries are
+     * written to a segment of the log, if the entry count in that segment meets the configured
+     * maximum entry count, the log will create a new segment and append new entries to that
+     * segment.
      * <p>
      * By default, the maximum entries per segment is {@code 1024 * 1024}.
      *
      * @param maxEntriesPerSegment The maximum number of entries allowed per segment.
      * @return The storage builder.
-     * @throws IllegalArgumentException If the {@code maxEntriesPerSegment} not greater than the default max entries
-     *     per segment
+     * @throws IllegalArgumentException If the {@code maxEntriesPerSegment} not greater than the
+     * default max entries per segment
      * @deprecated since 3.0.2
      */
     @Deprecated
@@ -820,15 +842,16 @@ public class SegmentedJournal<E> implements Journal<E> {
     /**
      * Sets the journal index density.
      * <p>
-     * The index density is the frequency at which the position of entries written to the journal will be recorded in an
-     * in-memory index for faster seeking.
+     *
+     * The index density is a number x, which means on every x't index the position of entries
+     * written to the journal will be recorded in an in-memory index for faster seeking.
      *
      * @param indexDensity the index density
      * @return the journal builder
-     * @throws IllegalArgumentException if the density is not between 0 and 1
+     * @throws IllegalArgumentException if the density is not larger then 0
      */
-    public Builder<E> withIndexDensity(double indexDensity) {
-      checkArgument(indexDensity > 0 && indexDensity < 1, "index density must be between 0 and 1");
+    public Builder<E> withIndexDensity(int indexDensity) {
+      checkArgument(indexDensity > 0, "index density must be larger then 0");
       this.indexDensity = indexDensity;
       return this;
     }
@@ -849,11 +872,11 @@ public class SegmentedJournal<E> implements Journal<E> {
     }
 
     /**
-     * Enables flushing buffers to disk when entries are committed to a segment, returning the builder for method
-     * chaining.
+     * Enables flushing buffers to disk when entries are committed to a segment, returning the
+     * builder for method chaining.
      * <p>
-     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time an entry is
-     * committed in a given segment.
+     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each
+     * time an entry is committed in a given segment.
      *
      * @return The storage builder.
      */
@@ -862,13 +885,14 @@ public class SegmentedJournal<E> implements Journal<E> {
     }
 
     /**
-     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the builder for method
-     * chaining.
+     * Sets whether to flush buffers to disk when entries are committed to a segment, returning the
+     * builder for method chaining.
      * <p>
-     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each time an entry is
-     * committed in a given segment.
+     * When flush-on-commit is enabled, log entry buffers will be automatically flushed to disk each
+     * time an entry is committed in a given segment.
      *
-     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a segment.
+     * @param flushOnCommit Whether to flush buffers to disk when entries are committed to a
+     * segment.
      * @return The storage builder.
      */
     public Builder<E> withFlushOnCommit(boolean flushOnCommit) {
@@ -887,7 +911,14 @@ public class SegmentedJournal<E> implements Journal<E> {
           maxEntrySize,
           maxEntriesPerSegment,
           indexDensity,
-          flushOnCommit);
+          flushOnCommit,
+          journalIndexFactory);
+    }
+
+    public Builder<E> withJournalIndexFactory(
+        final Supplier<JournalIndex> journalIndexFactory) {
+      this.journalIndexFactory = journalIndexFactory;
+      return this;
     }
   }
 }

--- a/storage/src/main/java/io/atomix/storage/journal/index/JournalIndex.java
+++ b/storage/src/main/java/io/atomix/storage/journal/index/JournalIndex.java
@@ -15,6 +15,8 @@
  */
 package io.atomix.storage.journal.index;
 
+import io.atomix.storage.journal.Indexed;
+
 /**
  * Journal index.
  */
@@ -23,10 +25,10 @@ public interface JournalIndex {
   /**
    * Adds an entry for the given index at the given position.
    *
-   * @param index the index for which to add the entry
+   * @param indexed the indexed entry for which to add the entry
    * @param position the position of the given index
    */
-  void index(long index, int position);
+  void index(Indexed indexed, int position);
 
   /**
    * Looks up the position of the given index.
@@ -37,10 +39,23 @@ public interface JournalIndex {
   Position lookup(long index);
 
   /**
-   * Truncates the index to the given index.
+   * Truncates the index to the given index, which means everything higher will be removed from the
+   * index
    *
    * @param index the index to which to truncate the index
    */
   void truncate(long index);
+
+  /**
+   * Compacts the index until the next stored index (exclusively), which means everything lower then
+   * the stored index will be removed.
+   *
+   * <p>Example Index: {5 -> 10; 10 -> 20; 15 -> 30}, when compact is called with index 11.
+   * The next lower stored index is 10, everything lower then this index will be removed. This means
+   * the mapping {5 -> 10}, should be removed.
+   *
+   * @param index the index to which to compact the index
+   */
+  void compact(long index);
 
 }

--- a/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -15,15 +15,15 @@
  */
 package io.atomix.storage.journal;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.JournalReader.Mode;
 import io.atomix.utils.serializer.Namespace;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
@@ -34,12 +34,11 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 /**
  * Base journal test.
@@ -48,6 +47,7 @@ import static org.junit.Assert.assertTrue;
  */
 @RunWith(Parameterized.class)
 public abstract class AbstractJournalTest {
+
   private static final Namespace NAMESPACE = Namespace.builder()
       .register(TestEntry.class)
       .register(byte[].class)
@@ -87,7 +87,7 @@ public abstract class AbstractJournalTest {
         .withNamespace(NAMESPACE)
         .withStorageLevel(storageLevel())
         .withMaxSegmentSize(maxSegmentSize)
-        .withIndexDensity(.2)
+        .withIndexDensity(5)
         .withCacheSize(cacheSize)
         .build();
   }

--- a/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import io.atomix.storage.StorageLevel;
 import io.atomix.storage.journal.JournalReader.Mode;
+import io.atomix.storage.journal.index.SparseJournalIndex;
 import io.atomix.utils.serializer.Namespace;
 import java.io.IOException;
 import java.nio.file.FileVisitResult;
@@ -87,8 +88,7 @@ public abstract class AbstractJournalTest {
         .withNamespace(NAMESPACE)
         .withStorageLevel(storageLevel())
         .withMaxSegmentSize(maxSegmentSize)
-        .withIndexDensity(5)
-        .withCacheSize(cacheSize)
+        .withJournalIndexFactory(() -> new SparseJournalIndex(5))
         .build();
   }
 

--- a/storage/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/index/SparseJournalIndexTest.java
@@ -15,71 +15,201 @@
  */
 package io.atomix.storage.journal.index;
 
-import org.junit.Test;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+
+import io.atomix.storage.journal.Indexed;
+import org.junit.Test;
 
 /**
  * Sparse journal index test.
  */
 public class SparseJournalIndexTest {
+
   @Test
-  public void testSparseJournalIndex() throws Exception {
-    JournalIndex index = new SparseJournalIndex(.2);
-    assertNull(index.lookup(1));
-    index.index(1, 2);
-    assertNull(index.lookup(1));
-    index.index(2, 4);
-    index.index(3, 6);
-    index.index(4, 8);
-    index.index(5, 10);
+  public void shouldNotFindIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+
+    // when
+    final Position position = index.lookup(1);
+
+    // then
+    assertNull(position);
+  }
+
+  public static Indexed asIndexedEntry(long index) {
+    return new Indexed(index, null, 0);
+  }
+
+  @Test
+  public void shouldFindIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+
+    // when
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+
+    // then
     assertEquals(5, index.lookup(5).index());
     assertEquals(10, index.lookup(5).position());
-    index.index(6, 12);
-    index.index(7, 14);
-    index.index(8, 16);
+
+  }
+
+  @Test
+  public void shouldFindLowerIndexWhenNotReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+
+    // when
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+
+    // then
     assertEquals(5, index.lookup(8).index());
     assertEquals(10, index.lookup(8).position());
-    index.index(9, 18);
-    index.index(10, 20);
+  }
+
+  @Test
+  public void shouldFindNextIndexWhenReachedDensity() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+
+    // when
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // then
     assertEquals(10, index.lookup(10).index());
     assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldTruncateIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
     index.truncate(8);
+
+    // then
     assertEquals(5, index.lookup(8).index());
     assertEquals(10, index.lookup(8).position());
     assertEquals(5, index.lookup(10).index());
     assertEquals(10, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldTruncateCompleteIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+    index.truncate(8);
+
+    // when
     index.truncate(4);
+
+    // then
     assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
+    assertNull(index.lookup(8));
+    assertNull(index.lookup(10));
+  }
+
+  @Test
+  public void shouldNotCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
+    index.compact(8);
+
+    // then
+    assertEquals(5, index.lookup(8).index());
+    assertEquals(10, index.lookup(8).position());
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+  }
+
+  @Test
+  public void shouldCompactIndex() {
+    // given - every 5 index is added
+    final JournalIndex index = new SparseJournalIndex(5);
+    // index entries
+    index.index(asIndexedEntry(1), 2);
+    index.index(asIndexedEntry(2), 4);
+    index.index(asIndexedEntry(3), 6);
+    index.index(asIndexedEntry(4), 8);
+    index.index(asIndexedEntry(5), 10);
+    index.index(asIndexedEntry(6), 12);
+    index.index(asIndexedEntry(7), 14);
+    index.index(asIndexedEntry(8), 16);
+    index.index(asIndexedEntry(9), 18);
+    index.index(asIndexedEntry(10), 20);
+
+    // when
+    index.compact(11);
+
+    // then
+    assertNull(index.lookup(4));
+    assertNull(index.lookup(5));
     assertNull(index.lookup(8));
 
-    index = new SparseJournalIndex(.2);
-    assertNull(index.lookup(100));
-    index.index(101, 2);
-    assertNull(index.lookup(1));
-    index.index(102, 4);
-    index.index(103, 6);
-    index.index(104, 8);
-    index.index(105, 10);
-    assertEquals(105, index.lookup(105).index());
-    assertEquals(10, index.lookup(105).position());
-    index.index(106, 12);
-    index.index(107, 14);
-    index.index(108, 16);
-    assertEquals(105, index.lookup(108).index());
-    assertEquals(10, index.lookup(108).position());
-    index.index(109, 18);
-    index.index(110, 20);
-    assertEquals(110, index.lookup(110).index());
-    assertEquals(20, index.lookup(110).position());
-    index.truncate(108);
-    assertEquals(105, index.lookup(108).index());
-    assertEquals(10, index.lookup(108).position());
-    assertEquals(105, index.lookup(110).index());
-    assertEquals(10, index.lookup(110).position());
-    index.truncate(104);
-    assertNull(index.lookup(104));
-    assertNull(index.lookup(108));
+    assertEquals(10, index.lookup(10).index());
+    assertEquals(20, index.lookup(10).position());
+    assertEquals(10, index.lookup(12).index());
+    assertEquals(20, index.lookup(12).position());
   }
 }


### PR DESCRIPTION
 In order to inject own JournalIndex from the outside (from Zeebe) we
 introduce a JournalIndex Supplier which is used in the Journal.
 The RaftPartition, Log etc pass the Supplier to the SegmentedJournal
 which uses that on creating new segments to pass an JournalIndex

 The JournalIndex interface got new method to compact the index. This
 means it removes stored indices lower then the given one. This is the
 opposite operation of truncate.

 On Indexing we use the complete Entry, such that it is possible for
 other Index implementations also take the complete entry into
 account.

This is the preparation for https://github.com/zeebe-io/zeebe/issues/3623


@npepinpe @deepthidevaki actually I don't care who reviews it since you both know about the current topic :smile: 