### PR TITLE
Add failure listeners to raft

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftServer.java
@@ -244,6 +244,13 @@ public interface RaftServer {
   void removeRoleChangeListener(RaftRoleChangeListener listener);
 
   /**
+   * Adds a failure listener
+   *
+   * @param failureListener
+   */
+  void addFailureListener(Runnable failureListener);
+
+  /**
    * Bootstraps a single-node cluster.
    *
    * <p>Bootstrapping a single-node cluster results in the server forming a new cluster to which

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -84,6 +84,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public void addFailureListener(Runnable failureListener) {
+    context.addFailureListener(failureListener);
+  }
+
+  @Override
   public CompletableFuture<RaftServer> bootstrap(Collection<MemberId> cluster) {
     return start(() -> cluster().bootstrap(cluster));
   }


### PR DESCRIPTION
- Add failure listeners to raft that listens to uncaught exceptions in tasks submitted to raft main thread.
- Raft partition shutdown when it observes a failure

closes #155 