### PR TITLE
fix(raft): step down if an append from ZeebeAppender fails

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/LeaderRole.java
@@ -1462,6 +1462,10 @@ public final class LeaderRole extends ActiveRole implements ZeebeLogAppender {
             (indexed, error) -> {
               if (error != null) {
                 appendListener.onWriteError(Throwables.getRootCause(error));
+                if (!(error instanceof StorageException)) {
+                  // step down. Otherwise the following event can get appended resulting in gaps
+                  raft.transition(Role.FOLLOWER);
+                }
               } else {
                 appendListener.onWrite(indexed);
                 replicate(indexed, appendListener);


### PR DESCRIPTION
Step down when an append from zeebe broker fails. Failure of appends due to other operation doesn't trigger a step down. In all cases they are external requests and will be retried by the sender.

closes #173