### PR TITLE
chore(utils): fix serialization bug

### DIFF
--- a/utils/src/main/java/io/atomix/utils/serializer/serializers/ByteBufferSerializer.java
+++ b/utils/src/main/java/io/atomix/utils/serializer/serializers/ByteBufferSerializer.java
@@ -29,7 +29,7 @@ public class ByteBufferSerializer extends Serializer<ByteBuffer> {
     output.writeBoolean(object.isDirect());
     output.writeBoolean(ByteOrder.LITTLE_ENDIAN.equals(object.order()));
     output.writeInt(object.remaining());
-    for (int i = object.position(); i < object.capacity(); i++) {
+    for (int i = object.position(); i < object.limit(); i++) {
       output.writeByte(object.get(i));
     }
   }

--- a/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
+++ b/utils/src/test/java/io/atomix/utils/serializer/serializers/ByteBufferSerializerTest.java
@@ -146,4 +146,46 @@ public class ByteBufferSerializerTest {
     assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
     assertEquals(value, deserialized.getLong(0));
   }
+
+  @Test
+  public void shouldSerializeBufferWithNonZeroPositionAndLimit() {
+    // given
+    final int capacity = Integer.BYTES * 4;
+    final int firstPosition = Integer.BYTES;
+    final int firstValue = 1;
+    final int secondPosition = Integer.BYTES;
+    final int secondValue = 2;
+    final ByteBuffer original =
+        ByteBuffer.allocate(capacity)
+            .order(ByteOrder.BIG_ENDIAN)
+            .putInt(firstPosition, firstValue)
+            .putInt(secondPosition, secondValue);
+
+    // when
+    original.position(secondPosition).limit(secondPosition + Integer.BYTES);
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
+    assertEquals(secondValue, deserialized.getInt(0));
+  }
+
+  @Test
+  public void shouldSerializeZeroLengthBuffers() {
+    // given
+    final int capacity = Integer.BYTES;
+    final int value = 1;
+    final ByteBuffer original =
+        ByteBuffer.allocate(capacity).order(ByteOrder.BIG_ENDIAN).putInt(0, value);
+
+    // when
+    original.position(capacity);
+    KRYO.writeObject(output, original);
+    final ByteBuffer deserialized = KRYO.readObject(input, ByteBuffer.class);
+
+    // then
+    assertEquals(ByteOrder.BIG_ENDIAN, deserialized.order());
+    assertEquals(0, deserialized.capacity());
+  }
 }


### PR DESCRIPTION
**Description**

Fixes a bug in the `ByteBufferSerializer` where buffers starting at a non-zero position were not being serialized properly.

Closes #178 