### PR TITLE
chore(storage): ignore index positions outside of current segment

### DIFF
--- a/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
+++ b/storage/src/main/java/io/atomix/storage/journal/MappedJournalSegmentReader.java
@@ -83,13 +83,20 @@ class MappedJournalSegmentReader<E> implements JournalReader<E> {
 
   @Override
   public void reset(long index) {
+    final long firstIndex = segment.index();
+    final long lastIndex = segment.lastIndex();
+
     reset();
-    Position position = this.index.lookup(index - 1);
-    if (position != null) {
+
+    final Position position = this.index.lookup(index - 1);
+    if (position != null && position.index() >= firstIndex && position.index() <= lastIndex) {
       currentEntry = new Indexed<>(position.index() - 1, null, 0);
       buffer.position(position.position());
+
+      nextEntry = null;
       readNext();
     }
+
     while (getNextIndex() < index && hasNext()) {
       next();
     }

--- a/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/AbstractJournalTest.java
@@ -82,13 +82,14 @@ public abstract class AbstractJournalTest {
   }
 
   protected SegmentedJournal<TestEntry> createJournal() {
+    final SparseJournalIndex index = new SparseJournalIndex(5);
     return SegmentedJournal.<TestEntry>builder()
         .withName("test")
         .withDirectory(PATH.toFile())
         .withNamespace(NAMESPACE)
         .withStorageLevel(storageLevel())
         .withMaxSegmentSize(maxSegmentSize)
-        .withJournalIndexFactory(() -> new SparseJournalIndex(5))
+        .withJournalIndexFactory(() -> index)
         .build();
   }
 

--- a/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
+++ b/storage/src/test/java/io/atomix/storage/journal/FileChannelJournalSegmentReaderTest.java
@@ -1,0 +1,71 @@
+package io.atomix.storage.journal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.atomix.storage.StorageLevel;
+import io.atomix.storage.journal.JournalReader.Mode;
+import io.atomix.storage.journal.index.SparseJournalIndex;
+import io.atomix.utils.serializer.Namespace;
+import java.io.File;
+import java.io.IOException;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class FileChannelJournalSegmentReaderTest {
+  private static final Namespace NAMESPACE = Namespace.builder().register(Integer.class).build();
+  private static final Integer ENTRY = 1;
+  private static final int ENTRY_SIZE =
+      NAMESPACE.serialize(ENTRY).length + Long.BYTES; // padding for checksum;
+
+  @Rule public final TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+  private File directory;
+
+  @Before
+  public void setUp() throws IOException {
+    directory = temporaryFolder.newFolder();
+  }
+
+  @Test
+  public void shouldResetBackwardsCorrectlyWhenUsingSameIndex() {
+    // given
+    final int entriesPerSegment = 7;
+    final SparseJournalIndex journalIndex = new SparseJournalIndex(5);
+    try (final SegmentedJournal<Integer> journal = createJournal(entriesPerSegment, journalIndex)) {
+      final SegmentedJournalWriter<Integer> writer = journal.writer();
+      final SegmentedJournalReader<Integer> reader = journal.openReader(1, Mode.ALL);
+
+      for (int i = 1; i <= entriesPerSegment; i++) {
+        writer.append(ENTRY);
+      }
+
+      writer.append(ENTRY);
+      final Indexed<Integer> previousEntry = writer.append(ENTRY);
+      final Indexed<Integer> currentEntry = writer.append(ENTRY);
+
+      reader.reset(currentEntry.index());
+      assertTrue(reader.hasNext());
+      assertEquals(currentEntry.index(), reader.next().index());
+
+      reader.reset(previousEntry.index());
+      assertTrue(reader.hasNext());
+      assertEquals(previousEntry.index(), reader.next().index());
+    }
+  }
+
+  private SegmentedJournal<Integer> createJournal(
+      final int entriesPerSegment, final SparseJournalIndex journalIndex) {
+    final int maxSegmentSize = (entriesPerSegment * ENTRY_SIZE) + JournalSegmentDescriptor.BYTES;
+    return SegmentedJournal.<Integer>builder()
+        .withName("test")
+        .withDirectory(directory)
+        .withNamespace(NAMESPACE)
+        .withStorageLevel(StorageLevel.DISK)
+        .withMaxSegmentSize(maxSegmentSize)
+        .withJournalIndexFactory(() -> journalIndex)
+        .build();
+  }
+}


### PR DESCRIPTION
**Description**

Adds a check to prevent using journal index positions that fall outside of the current segment when resetting a reader head.

This is only an issue when all segments share the same index (the test would pass without the fix iff they did not share the same index), which is the case on the Zeebe side.

Closes #187 