### PR TITLE
chore(raft): add info logging level on possible election triggers

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/AbstractAppender.java
@@ -252,7 +252,7 @@ abstract class AbstractAppender implements AutoCloseable {
         > raft.getTerm()) { // If we've received a greater term, update the term and transition back
       // to follower.
       log.info(
-          "Received higher term ({} > {}) from {}",
+          "Received higher term ({} > {}) from {}, stepping down",
           response.term(),
           raft.getTerm(),
           member.getMember());

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/roles/FollowerRole.java
@@ -111,6 +111,9 @@ public final class FollowerRole extends ActiveRole {
               if (leader != null
                   && event.type() == ClusterMembershipEvent.Type.MEMBER_REMOVED
                   && event.subject().id().equals(leader.memberId())) {
+                log.info(
+                    "Known leader {} was removed from cluster, sending poll requests",
+                    leader.memberId());
                 raft.setLeader(null);
                 sendPollRequests();
               }
@@ -274,7 +277,7 @@ public final class FollowerRole extends ActiveRole {
     if (raft.getFirstCommitIndex() == 0 || raft.getState() == RaftContext.State.READY) {
       final long missTime = System.currentTimeMillis() - lastHeartbeat;
       log.info(
-          "No heartbeat from {} in the last {} (calculated from last {} ms)",
+          "No heartbeat from {} in the last {} (calculated from last {} ms), sending poll requests",
           raft.getLeader(),
           delay,
           missTime);


### PR DESCRIPTION
**Description**

This PR adds some diagnostic logging to places that might trigger elections: sending poll requests, and stepping down as a leader.

The goal here is (combined with downgrading Atomix log level in Zeebe to info), is to be able to get a better idea of what might cause unexpected elections in Atomix.