### PR TITLE
chore(raft): remove failure listener

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -89,6 +89,11 @@ public class DefaultRaftServer implements RaftServer {
   }
 
   @Override
+  public void removeFailureListener(Runnable failureListener) {
+    context.removeFailureListener(failureListener);
+  }
+
+  @Override
   public CompletableFuture<RaftServer> bootstrap(Collection<MemberId> cluster) {
     return start(() -> cluster().bootstrap(cluster));
   }

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/RaftContext.java
@@ -312,6 +312,15 @@ public class RaftContext implements AutoCloseable {
   }
 
   /**
+   * Remove a failure listener
+   *
+   * @param failureListener
+   */
+  public void removeFailureListener(Runnable failureListener) {
+    failureListeners.remove(failureListener);
+  }
+
+  /**
    * Awaits a state change.
    *
    * @param state the state for which to wait

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/RaftPartition.java
@@ -93,6 +93,10 @@ public class RaftPartition implements Partition {
     }
   }
 
+  public void removeFailureListener(Runnable failureListener) {
+    server.removeFailureListener(failureListener);
+  }
+
   public void setJournalIndexFactory(Supplier<JournalIndex> journalIndexFactory) {
     if (server != null) {
       throw new IllegalStateException(

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/partition/impl/RaftPartitionServer.java
@@ -214,6 +214,10 @@ public class RaftPartitionServer implements Managed<RaftPartitionServer> {
     }
   }
 
+  public void removeFailureListener(Runnable failureListener) {
+    server.removeFailureListener(failureListener);
+  }
+
   public void removeRoleChangeListener(final RaftRoleChangeListener listener) {
     deferredRoleChangeListeners.remove(listener);
     server.removeRoleChangeListener(listener);


### PR DESCRIPTION
Expose api to remove a failure listener