### PR TITLE
chore(raft): transition to inactive before notifying failure listeners

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftFailureListener.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/RaftFailureListener.java
@@ -1,0 +1,14 @@
+package io.atomix.protocols.raft;
+
+import java.util.concurrent.CompletableFuture;
+
+@FunctionalInterface
+public interface RaftFailureListener {
+
+  /**
+   * Invoked by {@link io.atomix.protocols.raft.partition.RaftPartition} when raft fails.
+   *
+   * @return a future that should be completed when the actions taken by the listener is completed.
+   */
+  CompletableFuture<Void> onRaftFailed();
+}

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/impl/DefaultRaftServer.java
@@ -223,7 +223,7 @@ public class DefaultRaftServer implements RaftServer {
    * @return Indicates whether the server is running.
    */
   public boolean isRunning() {
-    return started;
+    return started && context.isRunning();
   }
 
   @Override

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/RaftTest.java
@@ -1732,6 +1732,8 @@ public class RaftTest extends ConcurrentTestCase {
     secondListener.await(1, TimeUnit.SECONDS);
     assertEquals(0, firstListener.getCount());
     assertEquals(0, secondListener.getCount());
+
+    assertEquals(server.getRole(), Role.INACTIVE);
   }
 
   private static final class FakeStatistics extends StorageStatistics {


### PR DESCRIPTION
By transitioning to inactive role, we prevent operations already submitted to the thread context to have no effect on the raft state. This is better than closing thread context because closing RaftPartition requires thread context to be open.