### PR TITLE
chore(raft): adds SnapshotStore#purgePendingSnapshots API

### DIFF
--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/SnapshotStore.java
@@ -2,6 +2,7 @@ package io.atomix.protocols.raft.storage.snapshot;
 
 import io.atomix.protocols.raft.storage.RaftStorage;
 import io.atomix.utils.time.WallClockTimestamp;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collection;
 
@@ -114,11 +115,18 @@ public interface SnapshotStore extends AutoCloseable {
   Snapshot newSnapshot(long index, long term, WallClockTimestamp timestamp);
 
   /**
-   * Removes committed and non-committed snapshots older than the given snapshot.
+   * Removes committed snapshots older than the given snapshot.
    *
-   * @param snapshot the snapshot to remove
+   * @param snapshot the snapshot will be the oldest remaining snapshots after
    */
   void purgeSnapshots(Snapshot snapshot);
+
+  /**
+   * Removes all pending snapshots.
+   *
+   * @throws IOException thrown if any error occurs attempting to purge the underlying snapshots
+   */
+  void purgePendingSnapshots() throws IOException;
 
   /**
    * Returns the path to the directory containing valid snapshots.

--- a/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/impl/DefaultSnapshotStore.java
+++ b/protocols/raft/src/main/java/io/atomix/protocols/raft/storage/snapshot/impl/DefaultSnapshotStore.java
@@ -214,6 +214,11 @@ public class DefaultSnapshotStore implements SnapshotStore {
   }
 
   @Override
+  public void purgePendingSnapshots() {
+    // nothing to do, as snapshots are temporary files
+  }
+
+  @Override
   public Path getPath() {
     return directory.toPath();
   }

--- a/protocols/raft/src/test/java/io/atomix/protocols/raft/roles/LeaderRoleTest.java
+++ b/protocols/raft/src/test/java/io/atomix/protocols/raft/roles/LeaderRoleTest.java
@@ -15,6 +15,7 @@ import io.atomix.protocols.raft.impl.RaftContext;
 import io.atomix.protocols.raft.session.RaftSessionRegistry;
 import io.atomix.protocols.raft.storage.log.RaftLogWriter;
 import io.atomix.protocols.raft.storage.log.entry.RaftLogEntry;
+import io.atomix.protocols.raft.storage.snapshot.SnapshotStore;
 import io.atomix.protocols.raft.zeebe.ZeebeEntry;
 import io.atomix.protocols.raft.zeebe.ZeebeLogAppender.AppendListener;
 import io.atomix.storage.StorageException;
@@ -59,6 +60,9 @@ public class LeaderRoleTest {
               return new Indexed<>(1, zeebeEntry, 45);
             });
     when(context.getLogWriter()).thenReturn(writer);
+
+    final SnapshotStore snapshotStore = mock(SnapshotStore.class);
+    when(context.getSnapshotStore()).thenReturn(snapshotStore);
 
     leadeRole = new LeaderRole(context);
     // since we mock RaftContext we should simulate leader close on transition


### PR DESCRIPTION
**Description**

This PR adds a new method on the `SnapshotStore` interface, which when called should purge all pending snapshots. It's currently called every time we abort an ongoing installation, as well as when we close the `PassiveRole`. I/O errors are handled by the caller.